### PR TITLE
CMake 3.15 and higher required for PREPEND list action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #   -DHDF5_DIR=<HDF5 dir> \
 #   -Dzstd_DIR=<path to zstd lib>/cmake/zstd
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
Instead of getting a cryptic failure due to an unsupported `PREPEND` list action, this PR imposes a minimum version of CMake that supports the `PREPEND` behavior.