### PR TITLE
Switch to using a ComponentFactory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(threaded_io_test
   UnrolledDeserializer.cc
   UnrolledSerializer.cc
   common_unrolling.cc
+  OutputerFactory.cc
   outputerFactoryGenerator.cc
   pds_reading.cc
   sourceFactoryGenerator.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ configure_file(ThreadedIOTestConfig.h.in ThreadedIOTestConfig.h)
 
 #make the library for testing
 add_library(configKeys configKeyValuePairs.cc)
+add_library(configParams ConfigurationParameters.cc)
 
 #make the library holding the root dictionaries
 REFLEX_GENERATE_DICTIONARY(G__sequence_classes SequenceFinderForBuiltins.h SELECTION classes_def.xml)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(threaded_io_test
   UnrolledDeserializer.cc
   UnrolledSerializer.cc
   common_unrolling.cc
+  ConfigurationParameters.cc
   OutputerFactory.cc
   outputerFactoryGenerator.cc
   pds_reading.cc
@@ -114,6 +115,7 @@ add_test(NAME SerializeOutputerTest COMMAND threaded_io_test EmptySource 1 1 0 1
 add_test(NAME SerializeOutputerVerboseTest COMMAND threaded_io_test EmptySource 1 1 0 10 SerializeOutputer=verbose)
 add_test(NAME PDSOutputerEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 PDSOutputer=test_empty.pds)
 add_test(NAME TestProductsPDS COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 PDSOutputer=test_prod.pds; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SharedPDSSource=test_prod.pds 1 1 0 10 TestProductsOutputer")
+add_test(NAME PDSOutputerAllOptionsEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 PDSOutputer=test_empty.pds:compressionLevel=8:compressionAlgorithm=LZ4:serializationAlgorithm=Unrolled)
 add_test(NAME TestProductsPDSUnrolled COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 PDSOutputer=test_prod_unroll.pds:serializationAlgorithm=Unrolled; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SharedPDSSource=test_prod_unroll.pds 1 1 0 10 TestProductsOutputer")
 add_test(NAME RootOutputerEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootOutputer=test_empty.root)
 add_test(NAME RootOutputerEmptySplitLevelTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootOutputer=test_empty.root:splitLevel=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,12 +44,15 @@ target_link_libraries(sequence_classes_dict PUBLIC ROOT::RIO ROOT::Net)
 
 add_executable(threaded_io_test
   DeserializeStrategy.cc
+  DummyOutputer.cc
+  SerializeOutputer.cc
   HDFOutputer.cc
   HDFSource.cc
   Lane.cc
   PDSOutputer.cc
   PDSSource.cc
   RepeatingRootSource.cc
+  RootOutputerConfig.cc
   RootOutputer.cc
   RootSource.cc
   SerialRootSource.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(sequence_classes_dict PUBLIC ROOT::RIO ROOT::Net)
 
 add_executable(threaded_io_test
   DeserializeStrategy.cc
+  EmptySource.cc
   DummyOutputer.cc
   SerializeOutputer.cc
   HDFOutputer.cc
@@ -70,6 +71,7 @@ add_executable(threaded_io_test
   OutputerFactory.cc
   outputerFactoryGenerator.cc
   pds_reading.cc
+  SourceFactory.cc
   sourceFactoryGenerator.cc
   threaded_io_test.cc)
 
@@ -125,8 +127,8 @@ add_test(NAME RootOutputerEmptySplitLevelTest COMMAND threaded_io_test EmptySour
 add_test(NAME RootOutputerEmptyAllOptionsTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootOutputer=test_empty.root:splitLevel=1:compressionLevel=1:compressionAlgorithm=LZMA:basketSize=32000:treeMaxVirtualSize=-1:autoFlush=900)
 add_test(NAME TestProductsROOT COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SerialRootSource=test_prod.root 1 1 0 10 TestProductsOutputer")
 add_test(NAME TestProductsROOTReplicated COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_repl.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test ReplicatedRootSource=test_prod_repl.root 1 1 0 10 TestProductsOutputer")
-add_test(NAME TestProductsROOTRepeating COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_rep.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test RepeatingRootSource=test_prod_rep.root:5 1 1 0 100 TestProductsOutputer")
-add_test(NAME TestProductsROOTRepeatingOneBranch COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_rep_1branch.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test RepeatingRootSource=test_prod_rep_1branch.root:5:floats 1 1 0 100 TestProductsOutputer")
+add_test(NAME TestProductsROOTRepeating COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_rep.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test RepeatingRootSource=test_prod_rep.root:repeat=5 1 1 0 100 TestProductsOutputer")
+add_test(NAME TestProductsROOTRepeatingOneBranch COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_rep_1branch.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test RepeatingRootSource=test_prod_rep_1branch.root:repeat=5:branchToRead=floats 1 1 0 100 TestProductsOutputer")
 add_test(NAME TBufferMergerRootOutputerEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 TBufferMergerRootOutputer=test_empty.root)
 add_test(NAME TBufferMergerRootOutputerEmptySplitLevelTest COMMAND threaded_io_test EmptySource 1 1 0 10 TBufferMergerRootOutputer=test_empty.root:splitLevel=1)
 add_test(NAME TBufferMergerRootOutputerEmptyAllOptionsTest COMMAND threaded_io_test EmptySource 1 1 0 10 TBufferMergerRootOutputer=test_empty.root:splitLevel=1:compressionLevel=1:compressionAlgorithm=LZMA:basketSize=32000:treeMaxVirtualSize=-1:autoFlush=900)

--- a/ComponentFactory.h
+++ b/ComponentFactory.h
@@ -1,0 +1,68 @@
+#if !defined(ComponentFactory_h)
+#define ComponentFactory_h
+
+#include <memory>
+#include <unordered_map>
+
+namespace cce::tf {
+
+  template <class T>
+    class ComponentFactory;
+
+  template<typename R, typename... Args>
+    class ComponentFactory<R*(Args...)> {
+  public:
+
+    using TemplateArgType = R*(Args...);
+    using CreatedType = R;
+
+    ComponentFactory(const ComponentFactory&) = delete;                   // stop default
+    const ComponentFactory& operator=(const ComponentFactory&) = delete;  // stop default
+
+    struct CMakerBase {
+      CMakerBase(const std::string& iName) { ComponentFactory<R*(Args...)>::get()->registerCMaker(this, iName);}
+      virtual std::unique_ptr<R> create(Args...) const = 0;
+      virtual ~CMakerBase() = default;
+    };
+    template <class TPlug>
+      struct CMaker : public CMakerBase {
+      CMaker(const std::string& iName) : CMakerBase(iName) {}
+      std::unique_ptr<R> create(Args... args) const override {
+        return std::make_unique<TPlug>(std::forward<Args>(args)...);
+      }
+    };
+
+    // ---------- const member functions ---------------------
+    std::unique_ptr<R> create(const std::string& iName, Args... args) const {
+      auto itFound =makers_.find(iName);
+      if(itFound == makers_.end()) {
+        return std::unique_ptr<R>();
+      }
+      return itFound->second->create(std::forward<Args>(args)...);
+    }
+
+    static ComponentFactory<R*(Args...)>* get();
+    // ---------- member functions ---------------------------
+    void registerCMaker(CMakerBase* iCMaker, const std::string& iName) {
+      makers_[iName] = iCMaker;
+    }
+
+  private:
+    ComponentFactory() { }
+    std::unordered_map<std::string, CMakerBase*> makers_;
+  };
+
+
+}
+
+#define REGISTER_COMPONENTFACTORY(_factory_)                                                               \
+  namespace cce::tf {                                                     \
+    template <>                                                                                                         \
+      cce::tf::ComponentFactory<_factory_::TemplateArgType>* cce::tf::ComponentFactory<_factory_::TemplateArgType>::get() { \
+      static cce::tf::ComponentFactory<_factory_::TemplateArgType> s_instance; \
+      return &s_instance;                                                                                               \
+    }                                                                                                                   \
+  };
+
+
+#endif

--- a/ConfigurationParameters.cc
+++ b/ConfigurationParameters.cc
@@ -12,6 +12,11 @@ namespace cce::tf {
   }
 
   template<>
+    unsigned int ConfigurationParameters::convert<unsigned int>(std::string const& iValue) {
+    return std::stoul(iValue);
+  }
+
+  template<>
   bool ConfigurationParameters::convert<bool>(std::string const& iValue) {
     return (iValue.empty()) or (
                                      (iValue[0] == 't') or (iValue[0] == 'T') or (iValue[0] == 'y') or (iValue[0] == 'Y')

--- a/ConfigurationParameters.cc
+++ b/ConfigurationParameters.cc
@@ -1,0 +1,20 @@
+#include "ConfigurationParameters.h"
+
+namespace cce::tf {
+  template<>
+    std::string ConfigurationParameters::convert<std::string>(std::string const& iValue) {
+    return iValue;
+  }
+  
+  template<>
+    int ConfigurationParameters::convert<int>(std::string const& iValue) {
+    return std::stoi(iValue);
+  }
+
+  template<>
+  bool ConfigurationParameters::convert<bool>(std::string const& iValue) {
+    return (not iValue.empty()) and (
+                                     (iValue[0] == 't') or (iValue[0] == 'T') or (iValue[0] == 'y') or (iValue[0] == 'Y')
+                                     );
+  }
+}

--- a/ConfigurationParameters.cc
+++ b/ConfigurationParameters.cc
@@ -13,7 +13,7 @@ namespace cce::tf {
 
   template<>
   bool ConfigurationParameters::convert<bool>(std::string const& iValue) {
-    return (not iValue.empty()) and (
+    return (iValue.empty()) or (
                                      (iValue[0] == 't') or (iValue[0] == 'T') or (iValue[0] == 'y') or (iValue[0] == 'Y')
                                      );
   }

--- a/ConfigurationParameters.h
+++ b/ConfigurationParameters.h
@@ -69,6 +69,9 @@ namespace cce::tf {
     int ConfigurationParameters::convert<int>(std::string const& iValue);
 
   template<>
+    unsigned int ConfigurationParameters::convert<unsigned int>(std::string const& iValue);
+
+  template<>
     bool ConfigurationParameters::convert<bool>(std::string const& iValue);
 
 

--- a/ConfigurationParameters.h
+++ b/ConfigurationParameters.h
@@ -1,0 +1,77 @@
+#if !defined(ConfigurationParameters_h)
+#define ConfigurationParameters_h
+
+#include <map>
+#include <vector>
+#include <string>
+#include <string_view>
+#include <optional>
+
+namespace cce::tf {
+
+  class ConfigurationParameters {
+  public:
+    using KeyValueMap = std::map<std::string, std::string, std::less<>>;
+
+    explicit ConfigurationParameters(KeyValueMap iKeyValues):
+    keyValues_{std::move(iKeyValues)} {
+      unusedKeys_.reserve(keyValues_.size());
+      for(auto const& kv: keyValues_) {
+        unusedKeys_.push_back(kv.first);
+      }
+    }
+
+    ConfigurationParameters() = delete;
+
+    template<typename T> 
+      std::optional<T> get(std::string_view iName) const {
+
+      auto itFound = keyValues_.find(iName);
+      if(itFound == keyValues_.end()) {
+        return std::nullopt;
+      }
+      keyUsed(iName);
+
+      return convert<T>(itFound->second);
+    }
+
+    template<typename T>
+      T get(std::string_view iName, T iDefault) const {
+      auto v = get<T>(iName);
+      if(v) {
+        return *v;
+      }
+      return iDefault;
+    }
+
+    std::vector<std::string_view> unusedKeys() const {
+      return unusedKeys_;
+    }
+
+  private:
+    template<typename T> static T convert(std::string const& iValue);
+
+    void keyUsed(std::string_view iName) const {
+      auto itUsed = std::lower_bound(unusedKeys_.begin(), unusedKeys_.end(), iName);
+      if(itUsed != unusedKeys_.end() and *itUsed == iName) {
+        unusedKeys_.erase(itUsed);
+      }
+    }
+
+    KeyValueMap keyValues_;
+    mutable std::vector<std::string_view> unusedKeys_;
+  };
+
+  template<>
+    std::string ConfigurationParameters::convert<std::string>(std::string const& iValue);
+  
+  template<>
+    int ConfigurationParameters::convert<int>(std::string const& iValue);
+
+  template<>
+    bool ConfigurationParameters::convert<bool>(std::string const& iValue);
+
+
+}
+
+#endif

--- a/DummyOutputer.cc
+++ b/DummyOutputer.cc
@@ -1,0 +1,18 @@
+#include "DummyOutputer.h"
+#include "OutputerFactory.h"
+#include <iostream>
+
+namespace cce::tf {
+namespace {
+    class Maker : public OutputerMakerBase {
+  public:
+    Maker(): OutputerMakerBase("DummyOutputer") {}
+    std::unique_ptr<OutputerBase> create(unsigned int iNLanes, ConfigurationParameters const& params) const final {
+      bool useProductReady = params.get<bool>("useProductReady",false);
+      return std::make_unique<DummyOutputer>(useProductReady);
+    }
+    };
+
+  Maker s_maker;
+}
+}

--- a/EmptySource.cc
+++ b/EmptySource.cc
@@ -1,0 +1,15 @@
+#include "EmptySource.h"
+#include "SourceFactory.h"
+
+using namespace cce::tf;
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("EmptySource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        return std::make_unique<EmptySource>(iNEvents);
+    }
+    };
+
+  Maker s_maker;
+}

--- a/HDFOutputer.cc
+++ b/HDFOutputer.cc
@@ -178,15 +178,6 @@ namespace {
 
       auto batchSize = params.get<int>("batchSize", 1);
 
-      auto unusedOptions = params.unusedKeys();
-      if(not unusedOptions.empty()) {
-        std::cout <<"Unused options in HDFOutputer\n";
-        for(auto const& key: unusedOptions) {
-          std::cout <<"  '"<<key<<"'"<<std::endl;
-        }
-        return {};
-      }
-
       return std::make_unique<HDFOutputer>(*fileName, iNLanes, batchSize);
     }
   };

--- a/HDFSource.cc
+++ b/HDFSource.cc
@@ -1,4 +1,6 @@
 #include "HDFSource.h"
+#include "SourceFactory.h"
+#include "ReplicatedSharedSource.h"
 
 #include "TClass.h"
 #include "TBufferFile.h"
@@ -160,4 +162,21 @@ void HDFSource::deserializeDataProducts(buffer_iterator it, buffer_iterator itEn
     ++it;
   }
   assert(it==itEnd);
+}
+
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("HDFSource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        auto fileName = params.get<std::string>("fileName");
+        if(not fileName) {
+          std::cout <<"no file name given\n";
+          return {};
+        }
+        return std::make_unique<ReplicatedSharedSource<HDFSource>>(iNLanes, iNEvents, *fileName);
+    }
+    };
+
+  Maker s_maker;
 }

--- a/OutputerFactory.cc
+++ b/OutputerFactory.cc
@@ -1,0 +1,6 @@
+#include "OutputerFactory.h"
+
+using namespace cce::tf;
+
+REGISTER_COMPONENTFACTORY(OutputerFactory)
+

--- a/OutputerFactory.h
+++ b/OutputerFactory.h
@@ -3,11 +3,12 @@
 
 #include "ComponentFactory.h"
 #include "OutputerBase.h"
+#include "ConfigurationParameters.h"
 #include <map>
 
 
 namespace cce::tf {
-  using OutputerFactory = ComponentFactory<OutputerBase*(unsigned int, std::map<std::string,std::string> const&)>;
+  using OutputerFactory = ComponentFactory<OutputerBase*(unsigned int, ConfigurationParameters const&)>;
   using OutputerMakerBase = OutputerFactory::CMakerBase;
 }
 

--- a/OutputerFactory.h
+++ b/OutputerFactory.h
@@ -1,0 +1,15 @@
+#if !defined(OutputerFactory_h)
+#define OutputerFactory_h
+
+#include "ComponentFactory.h"
+#include "OutputerBase.h"
+#include <map>
+
+
+namespace cce::tf {
+  using OutputerFactory = ComponentFactory<OutputerBase*(unsigned int, std::map<std::string,std::string> const&)>;
+  using OutputerMakerBase = OutputerFactory::CMakerBase;
+}
+
+#endif
+

--- a/PDSOutputer.cc
+++ b/PDSOutputer.cc
@@ -330,16 +330,6 @@ namespace {
         return {};
       }
       
-      auto unusedOptions = params.unusedKeys();
-      if(not unusedOptions.empty()) {
-        std::cout <<"Unused options in PDSOutputer\n";
-        for(auto const& key: unusedOptions) {
-          std::cout <<"  '"<<key<<"'"<<std::endl;
-        }
-        return {};
-      }
-
-      
       return std::make_unique<PDSOutputer>(*fileName,iNLanes, compression, compressionLevel, serialization);
     }
     

--- a/PDSSource.cc
+++ b/PDSSource.cc
@@ -1,5 +1,7 @@
 #include "PDSSource.h"
 #include "TClass.h"
+#include "SourceFactory.h"
+#include "ReplicatedSharedSource.h"
 
 #include "Deserializer.h"
 #include "UnrolledDeserializer.h"
@@ -75,3 +77,19 @@ PDSSource::~PDSSource() {
   }
 }
 
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("ReplicatedPDSSource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        auto fileName = params.get<std::string>("fileName");
+        if(not fileName) {
+          std::cout <<"no file name given\n";
+          return {};
+        }
+        return std::make_unique<ReplicatedSharedSource<PDSSource>>(iNLanes, iNEvents, *fileName);
+    }
+    };
+
+  Maker s_maker;
+}

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ Reads the first N events from a standard ROOT file at construction time. The des
 ```
 or
 ```
-> threaded_io_test RepeatingRootSource=test.root:5 1 1 0 1000
+> threaded_io_test RepeatingRootSource=test.root:repeat=5 1 1 0 1000
 ```
 or
 ```
-> threaded_io_test RepeatingRootSource=test.root:5:ints 1 1 0 1000
+> threaded_io_test RepeatingRootSource=test.root:repeat=5:branchToRead=ints 1 1 0 1000
 ```
 
 

--- a/RootOutputer.cc
+++ b/RootOutputer.cc
@@ -1,7 +1,8 @@
-
 #include <iostream>
 
 #include "RootOutputer.h"
+#include "RootOutputerConfig.h"
+#include "OutputerFactory.h"
 
 #include "TTree.h"
 #include "TBranch.h"
@@ -101,4 +102,20 @@ void RootOutputer::write(unsigned int iLaneIndex, EventIdentifier const& iEventI
   
 void RootOutputer::printSummary() const {
   std::cout <<"RootOutputer total time: "<<accumulatedTime_.count()<<"us\n";
+}
+
+namespace {
+  class Maker : public OutputerMakerBase {
+  public:
+    Maker(): OutputerMakerBase("RootOutputer") {}
+    std::unique_ptr<OutputerBase> create(unsigned int iNLanes, ConfigurationParameters const& params) const final {
+      auto result = parseRootConfig(params);
+      if(not result) {
+        return {};
+      }
+      return std::make_unique<RootOutputer>(result->first,iNLanes, outputerConfig<RootOutputer::Config>(result->second));
+    }
+    };
+
+  Maker s_maker;
 }

--- a/RootOutputerConfig.cc
+++ b/RootOutputerConfig.cc
@@ -1,0 +1,23 @@
+#include "RootOutputerConfig.h"
+#include "ConfigurationParameters.h"
+#include <iostream>
+
+namespace cce::tf {
+  std::optional<std::pair<std::string, RootOutputerConfig>> parseRootConfig(ConfigurationParameters const& params) {
+    auto fileName = params.get<std::string>("fileName");
+    if(not fileName) {
+      std::cout <<"no file name given for Outputer\n";
+      return std::nullopt;
+    }
+
+    RootOutputerConfig config;
+    config.splitLevel_ = params.get<int>("splitLevel",config.splitLevel_);
+
+    config.compressionLevel_ = params.get<int>("compressionLevel", config.compressionLevel_);
+    config.compressionAlgorithm_ = params.get<std::string>("compressionAlgorithm", config.compressionAlgorithm_);
+    config.basketSize_ = params.get<int>("basketSize", config.basketSize_);
+    config.treeMaxVirtualSize_ =  params.get<int>("treeMaxVirtualSize", config.treeMaxVirtualSize_);
+    config.autoFlush_ = params.get<int>("autoFlush", config.autoFlush_);
+    return std::make_pair(*fileName,config);
+  }
+}

--- a/RootOutputerConfig.h
+++ b/RootOutputerConfig.h
@@ -1,0 +1,36 @@
+#if !defined(RootOutputerConfig_h)
+#define RootOutputerConfig_h
+
+#include <string>
+#include <optional>
+#include <utility>
+
+namespace cce::tf {
+  struct RootOutputerConfig {
+    int splitLevel_=99;
+    int compressionLevel_=9;
+    std::string compressionAlgorithm_="";
+    int basketSize_=16384;
+    int treeMaxVirtualSize_=-1;
+    int autoFlush_=-1;
+  };
+
+  template<typename T>
+  inline T outputerConfig(RootOutputerConfig const& iConfig) {
+    T config;
+    config.splitLevel_ = iConfig.splitLevel_;
+    config.compressionLevel_ = iConfig.compressionLevel_;
+    config.compressionAlgorithm_ = iConfig.compressionAlgorithm_;
+    config.basketSize_ = iConfig.basketSize_;
+    config.treeMaxVirtualSize_ = iConfig.treeMaxVirtualSize_;
+    config.autoFlush_ = iConfig.autoFlush_;
+    return config;
+  }
+
+  class ConfigurationParameters;
+
+  std::optional<std::pair<std::string, RootOutputerConfig>> parseRootConfig(ConfigurationParameters const& params);
+}
+
+
+#endif

--- a/RootSource.cc
+++ b/RootSource.cc
@@ -1,4 +1,7 @@
 #include "RootSource.h"
+#include "SourceFactory.h"
+#include "ReplicatedSharedSource.h"
+
 #include <iostream>
 #include "TBranch.h"
 #include "TTree.h"
@@ -71,4 +74,21 @@ bool RootSource::readEvent(long iEventIndex) {
     return true;
   }
   return false;
+}
+
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("ReplicatedRootSource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        auto fileName = params.get<std::string>("fileName");
+        if(not fileName) {
+          std::cout <<"no file name given\n";
+          return {};
+        }
+        return std::make_unique<ReplicatedSharedSource<RootSource>>(iNLanes, iNEvents, *fileName);
+    }
+    };
+
+  Maker s_maker;
 }

--- a/SerialRootSource.cc
+++ b/SerialRootSource.cc
@@ -1,4 +1,5 @@
 #include "SerialRootSource.h"
+#include "SourceFactory.h"
 
 #include "TTree.h"
 #include "TBranch.h"
@@ -105,3 +106,20 @@ void SerialRootDelayedRetriever::getAsync(DataProductRetriever& dataProduct, int
       task.doneWaiting();
     });
 };
+
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("SerialRootSource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        auto fileName = params.get<std::string>("fileName");
+        if(not fileName) {
+          std::cout <<"no file name given\n";
+          return {};
+        }
+        return std::make_unique<SerialRootSource>(iNLanes, iNEvents, *fileName);
+    }
+    };
+
+  Maker s_maker;
+}

--- a/SerializeOutputer.cc
+++ b/SerializeOutputer.cc
@@ -1,0 +1,18 @@
+#include "SerializeOutputer.h"
+#include "OutputerFactory.h"
+#include <iostream>
+
+namespace cce::tf {
+namespace {
+    class Maker : public OutputerMakerBase {
+  public:
+    Maker(): OutputerMakerBase("SerializeOutputer") {}
+    std::unique_ptr<OutputerBase> create(unsigned int iNLanes, ConfigurationParameters const& params) const final {
+      bool verbose = params.get<bool>("verbose",false);
+      return std::make_unique<SerializeOutputer>(iNLanes, verbose);
+    }
+    };
+
+  Maker s_maker;
+}
+}

--- a/SharedPDSSource.cc
+++ b/SharedPDSSource.cc
@@ -1,4 +1,5 @@
 #include "SharedPDSSource.h"
+#include "SourceFactory.h"
 #include "Deserializer.h"
 #include "UnrolledDeserializer.h"
 
@@ -123,4 +124,22 @@ std::chrono::microseconds SharedPDSSource::deserializeTime() const {
     time += l.deserializeTime_;
   }
   return time;
+}
+
+
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("SharedPDSSource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        auto fileName = params.get<std::string>("fileName");
+        if(not fileName) {
+          std::cout <<"no file name given\n";
+          return {};
+        }
+        return std::make_unique<SharedPDSSource>(iNLanes, iNEvents, *fileName);
+    }
+    };
+
+  Maker s_maker;
 }

--- a/SourceFactory.cc
+++ b/SourceFactory.cc
@@ -1,0 +1,6 @@
+#include "SourceFactory.h"
+
+using namespace cce::tf;
+
+REGISTER_COMPONENTFACTORY(SourceFactory)
+

--- a/SourceFactory.h
+++ b/SourceFactory.h
@@ -1,0 +1,16 @@
+#if !defined(SourceFactory_h)
+#define SourceFactory_h
+
+#include "ComponentFactory.h"
+#include "SharedSourceBase.h"
+#include "ConfigurationParameters.h"
+#include <map>
+
+
+namespace cce::tf {
+  using SourceFactory = ComponentFactory<SharedSourceBase*(unsigned int, unsigned long long, ConfigurationParameters const&)>;
+  using SourceMakerBase = SourceFactory::CMakerBase;
+}
+
+#endif
+

--- a/TestProductsOutputer.cc
+++ b/TestProductsOutputer.cc
@@ -1,5 +1,6 @@
 #include "TestProductsOutputer.h"
 #include "DataProductRetriever.h"
+#include "OutputerFactory.h"
 
 #include <vector>
 #include <iostream>
@@ -63,4 +64,16 @@ void TestProductsOutputer::outputAsync(unsigned int iLaneIndex, EventIdentifier 
 
 void TestProductsOutputer::printSummary() const {
   std::cout <<"\nOutputer time: N/A"<<std::endl;
+}
+
+namespace {
+    class TestProductsMaker : public OutputerMakerBase {
+  public:
+    TestProductsMaker(): OutputerMakerBase("TestProductsOutputer") {}
+    std::unique_ptr<OutputerBase> create(unsigned int iNLanes, ConfigurationParameters const& params) const final {
+      return std::make_unique<TestProductsOutputer>(iNLanes);
+    }
+    };
+
+  TestProductsMaker s_maker;
 }

--- a/TestProductsSource.cc
+++ b/TestProductsSource.cc
@@ -1,4 +1,5 @@
 #include "TestProductsSource.h"
+#include "SourceFactory.h"
 #include "TClass.h"
 
 #include <iostream>
@@ -81,4 +82,16 @@ void TestProductsSource::printSummary() const {
 void TestProductsSource::readEventAsync(unsigned int iLane, long iEventIndex,  OptionalTaskHolder iTask) {
   delayedPerLane_[iLane].setEventIndex(iEventIndex);
   iTask.runNow();
+}
+
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("TestProductsSource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        return std::make_unique<TestProductsSource>(iNLanes, iNEvents);
+    }
+    };
+
+  Maker s_maker;
 }

--- a/TextDumpOutputer.cc
+++ b/TextDumpOutputer.cc
@@ -1,4 +1,6 @@
 #include "TextDumpOutputer.h"
+#include "OutputerFactory.h"
+#include "ConfigurationParameters.h"
 #include "DataProductRetriever.h"
 #include <iostream>
 
@@ -53,3 +55,17 @@ void TextDumpOutputer::printSummary() const {
   }
 }
 
+
+namespace {
+    class TextDumperMaker : public OutputerMakerBase {
+  public:
+    TextDumperMaker(): OutputerMakerBase("TextDumpOutputer") {}
+    std::unique_ptr<OutputerBase> create(unsigned int iNLanes, ConfigurationParameters const& params) const final {
+      bool perEvent = params.get<bool>("perEvent",true);
+      bool summary = params.get<bool>("summary", false);
+      return std::make_unique<TextDumpOutputer>(perEvent, summary);
+    }
+    };
+
+  TextDumperMaker s_maker;
+}

--- a/configKeyValuePairs.cc
+++ b/configKeyValuePairs.cc
@@ -6,6 +6,8 @@ namespace cce::tf {
     ConfigKeyValueMap keyValues;
     std::string::size_type start=0;
     std::string::size_type pos;
+
+    bool firstEntry = true;
     do {
       pos = iToParse.find(':',start);
       std::string keyValue;
@@ -24,8 +26,24 @@ namespace cce::tf {
       if( (pos = keyValue.find('=')) != std::string::npos ) {
 	keyValues.emplace(keyValue.substr(0,pos), keyValue.substr(pos+1));
       } else {
-	keyValues.emplace(keyValue,"");
+        if(firstEntry) {
+          //this might be a file name
+          auto pos = keyValue.find('/',0);
+          if(pos != std::string::npos) {
+            keyValues.emplace("fileName",keyValue);
+          } else {
+            pos = keyValue.find('.',0);
+            if(pos != std::string::npos) {
+              keyValues.emplace("fileName",keyValue);
+            } else {
+              keyValues.emplace(keyValue,"");
+            }
+          }
+        } else {
+          keyValues.emplace(keyValue,"");
+        }
       }
+      firstEntry = false;
     } while(start != std::string::npos);
     return keyValues;
   }

--- a/configKeyValuePairs.cc
+++ b/configKeyValuePairs.cc
@@ -2,8 +2,8 @@
 
 namespace cce::tf {
 
-  std::map<std::string,std::string> configKeyValuePairs(std::string_view iToParse) {
-    std::map<std::string,std::string> keyValues;
+  ConfigKeyValueMap configKeyValuePairs(std::string_view iToParse) {
+    ConfigKeyValueMap keyValues;
     std::string::size_type start=0;
     std::string::size_type pos;
     do {

--- a/configKeyValuePairs.h
+++ b/configKeyValuePairs.h
@@ -5,7 +5,8 @@
 #include <string_view>
 namespace cce::tf {
 
-  std::map<std::string,std::string> configKeyValuePairs(std::string_view iToParse);
+  using ConfigKeyValueMap = std::map<std::string, std::string, std::less<>>;
+  ConfigKeyValueMap configKeyValuePairs(std::string_view iToParse);
 }
 
 #endif

--- a/outputerFactoryGenerator.cc
+++ b/outputerFactoryGenerator.cc
@@ -1,217 +1,31 @@
 #include "outputerFactoryGenerator.h"
 #include "OutputerFactory.h"
-#include "RootOutputer.h"
-#include "SerializeOutputer.h"
-#include "DummyOutputer.h"
-#include "TextDumpOutputer.h"
-#include "TBufferMergerRootOutputer.h"
-#include "TestProductsOutputer.h"
 #include "configKeyValuePairs.h"
-
-namespace {
-  struct RootConfig {
-    int splitLevel_=99;
-    int compressionLevel_=9;
-    std::string compressionAlgorithm_="";
-    int basketSize_=16384;
-    int treeMaxVirtualSize_=-1;
-    int autoFlush_=-1;
-  };
-
-  template<typename T>
-  T outputerConfig(RootConfig const& iConfig) {
-    T config;
-    config.splitLevel_ = iConfig.splitLevel_;
-    config.compressionLevel_ = iConfig.compressionLevel_;
-    config.compressionAlgorithm_ = iConfig.compressionAlgorithm_;
-    config.basketSize_ = iConfig.basketSize_;
-    config.treeMaxVirtualSize_ = iConfig.treeMaxVirtualSize_;
-    config.autoFlush_ = iConfig.autoFlush_;
-    return config;
-  }
-  std::pair<bool, std::string> preParseTBufferMerger(std::string_view iOptions) {
-    std::string remainingOptions{iOptions};
-    auto pos = remainingOptions.find("concurrentWrite=");
-    bool set = true;
-    if(pos != std::string::npos) {
-      set = (remainingOptions[pos+16] == 'y' or remainingOptions[pos+16] == 'Y') ;
-      auto size = 17;
-      if(remainingOptions.size() > pos+17) {
-        auto npos = remainingOptions.find(pos+17,':');
-        if(npos != std::string::npos) {
-          size = npos - pos;
-        }
-      }
-      remainingOptions.replace(pos,size,"");
-    }
-    return std::make_pair(set, remainingOptions);
-  }
-
-  std::optional<std::pair<std::string, RootConfig>> parseRootConfig(std::string_view iOptions) {
-    std::string fileName{iOptions};
-    RootConfig config;
-    auto pos = fileName.find(':');
-    if(pos != std::string::npos) {
-      auto remainingOptions = fileName.substr(pos+1);
-      fileName = fileName.substr(0,pos);
-
-      auto keyValues = cce::tf::configKeyValuePairs(remainingOptions);
-      int foundOptions = 0;
-      auto itFound = keyValues.find("splitLevel");
-      if(itFound != keyValues.end()) {
-	config.splitLevel_ = std::stoul(itFound->second);
-	++foundOptions;
-      }
-      itFound = keyValues.find("compressionLevel");
-      if(itFound != keyValues.end()) {
-	config.compressionLevel_ = std::stoul(itFound->second);
-	++foundOptions;
-      }
-      itFound = keyValues.find("compressionAlgorithm");
-      if(itFound != keyValues.end()) {
-	config.compressionAlgorithm_ = itFound->second;
-	++foundOptions;
-      }
-      itFound = keyValues.find("basketSize");
-      if(itFound != keyValues.end()) {
-	config.basketSize_ = std::stoul(itFound->second);
-	++foundOptions;
-      }
-      itFound = keyValues.find("treeMaxVirtualSize");
-      if(itFound != keyValues.end()) {
-	config.treeMaxVirtualSize_ = std::stoul(itFound->second);
-	++foundOptions;
-      }
-      itFound = keyValues.find("autoFlush");
-      if(itFound != keyValues.end()) {
-	config.autoFlush_ = std::stoul(itFound->second);
-	++foundOptions;
-      }
-      if(foundOptions != keyValues.size()) {
-	std::cout <<"Unknown options for RootOutputer "<<remainingOptions<<std::endl;
-	for(auto const& kv: keyValues) {
-	  std::cout <<kv.first<<" "<<kv.second<<std::endl;
-	}
-	return std::nullopt;
-      }
-    }
-    return std::make_pair(fileName,config);
-  }
-
-  struct TextDumpConfig {
-    bool perEvent=true;
-    bool summary=false;
-  };
-
-  std::optional<TextDumpConfig> parseTextDumpConfig(std::string_view iOptions) {
-    TextDumpConfig conf;
-    auto keyValues = cce::tf::configKeyValuePairs(iOptions);
-    auto itFound = keyValues.find("perEvent");
-    int count = 0;
-    if(itFound != keyValues.end()) {
-      if(not itFound->second.empty() and itFound->second[0]!='t') {
-        conf.perEvent = false;
-      }
-      ++count;
-    }
-    itFound = keyValues.find("summary");
-    if(itFound != keyValues.end()) {
-      if(itFound->second.empty() or itFound->second[0]=='t') {
-        conf.summary = true;
-      }
-      ++count;
-    }
-    if(keyValues.size() != count) {
-      std::cout <<"unknown options passed to TextDumpOutputer, only use 'perEvent' and 'summary'"<<std::endl;
-      return std::nullopt;
-    }
-    return conf;
-  }
-}
+#include <iostream>
 
 std::function<std::unique_ptr<cce::tf::OutputerBase>(unsigned int)>
 cce::tf::outputerFactoryGenerator(std::string_view iType, std::string_view iOptions) {
   std::function<std::unique_ptr<OutputerBase>(unsigned int)> outFactory;
-  
-  if(iType == "PDSOutputer") {
 
-    std::string fileName{iOptions};
-    auto pos = fileName.find(':');
-    ConfigKeyValueMap keyValues;
-    if(pos != std::string::npos) {
-      auto remainingOptions = fileName.substr(pos+1);
-      fileName = fileName.substr(0,pos);
-
-      keyValues = cce::tf::configKeyValuePairs(remainingOptions);
+  auto keyValues = cce::tf::configKeyValuePairs(iOptions);
+  outFactory = [type=std::string(iType), params=ConfigurationParameters(keyValues)](unsigned int iNLanes) {
+    auto maker = OutputerFactory::get()->create(type, iNLanes, params);
+    if(not maker) {
+      return maker;
     }
-    keyValues["fileName"] = fileName;
-
-    outFactory = [params = ConfigurationParameters(keyValues)](unsigned int nLanes) { return OutputerFactory::get()->create("PDSOutputer", nLanes, params); };
-    return outFactory;
-  } else if(iType == "RootOutputer") {
-    auto result = parseRootConfig(iOptions);
-    if(not result) {
-      return outFactory;
-    }
-    auto fileName = result->first;
-    auto config = outputerConfig<RootOutputer::Config>(result->second);
     
-    outFactory = [fileName,config](unsigned int nLanes) { return std::make_unique<RootOutputer>(fileName, nLanes, config);};
-  } else if(iType == "TBufferMergerRootOutputer") {
-    auto preParse = preParseTBufferMerger(iOptions);
-    auto result = parseRootConfig(preParse.second);
-    if(not result) {
-      return outFactory;
-    }
-    auto fileName = result->first;
-    auto config = outputerConfig<TBufferMergerRootOutputer::Config>(result->second);
-    config.concurrentWrite = preParse.first;
-
-    outFactory = [fileName,config](unsigned int nLanes) { return std::make_unique<TBufferMergerRootOutputer>(fileName, nLanes, config);};
-  } else if(iType == "SerializeOutputer") {
-    bool verbose = false;
-    if(not iOptions.empty()) {
-      if(iOptions == "verbose") {
-        verbose = true;
-      }else {
-        std::cout <<"Unknown option for SerizeOutputer: "<<iOptions<<std::endl;
-        return outFactory;
+    //make sure all parameters given were used
+    auto unusedOptions = params.unusedKeys();
+    if(not unusedOptions.empty()) {
+      std::cout <<"Unused options in "<<type<<"\n";
+      for(auto const& key: unusedOptions) {
+        std::cout <<"  '"<<key<<"'"<<std::endl;
       }
+      return decltype(maker)();
     }
-    outFactory = [verbose](unsigned int nLanes) {return std::make_unique<SerializeOutputer>(nLanes,verbose);};
-  } else if(iType == "DummyOutputer") {
-    bool useProductReady = false;
-    if(not iOptions.empty()) {
-      if(iOptions != "useProductReady") {
-	std::cout <<"Unknown option for DummyOutputer: "<<iOptions<<std::endl;
-	return outFactory;
-      }
-      useProductReady = true;
-    }
-    outFactory = [useProductReady](unsigned int) { return std::make_unique<DummyOutputer>(useProductReady);};
-  } else if(iType == "HDFOutputer") {
 
-    std::string fileName{iOptions};
-    auto pos = fileName.find(':');
-    ConfigKeyValueMap keyValues;
-    if(pos != std::string::npos) {
-      auto remainingOptions = fileName.substr(pos+1);
-      fileName = fileName.substr(0,pos);
+    return maker;
+  };
 
-      keyValues = cce::tf::configKeyValuePairs(remainingOptions);
-    }
-    keyValues["fileName"] = fileName;
-
-    outFactory = [params=ConfigurationParameters(keyValues)](unsigned int nLanes) { return OutputerFactory::get()->create("HDFOutputer", nLanes, params); };
-    return outFactory;
-  } else if(iType == "TextDumpOutputer") {
-    auto result = parseTextDumpConfig(iOptions);
-    if(not result) {
-      return outFactory;
-    }
-    outFactory = [config = *result](unsigned int) { return std::make_unique<TextDumpOutputer>(config.perEvent, config.summary);};
-  } else if(iType == "TestProductsOutputer") {
-    outFactory = [](unsigned int iNLanes) { return std::make_unique<TestProductsOutputer>(iNLanes);};
-  }
   return outFactory;
 }

--- a/outputerFactoryGenerator.cc
+++ b/outputerFactoryGenerator.cc
@@ -98,38 +98,6 @@ namespace {
     return std::make_pair(fileName,config);
   }
 
-  /*
-  struct HDFConfig {
-    int maxBatchSize=1;
-  };
-
-  std::optional<std::pair<std::string, HDFConfig>> parseHDFConfig(std::string_view iOptions) {
-    std::string fileName{iOptions};
-    HDFConfig config;
-    auto pos = fileName.find(':');
-    if(pos != std::string::npos) {
-      auto remainingOptions = fileName.substr(pos+1);
-      fileName = fileName.substr(0,pos);
-
-      auto keyValues = cce::tf::configKeyValuePairs(remainingOptions);
-      int foundOptions = 0;
-      auto itFound = keyValues.find("batchSize");
-      if(itFound != keyValues.end()) {
-	config.maxBatchSize = std::stoul(itFound->second);
-	++foundOptions;
-      }
-      if(foundOptions != keyValues.size()) {
-	std::cout <<"Unknown options for HDFOutputer "<<remainingOptions<<std::endl;
-	for(auto const& kv: keyValues) {
-	  std::cout <<kv.first<<" "<<kv.second<<std::endl;
-	}
-	return std::nullopt;
-      }
-    }
-    return std::make_pair(fileName,config);
-  }
-  */
-
   struct TextDumpConfig {
     bool perEvent=true;
     bool summary=false;
@@ -169,7 +137,7 @@ cce::tf::outputerFactoryGenerator(std::string_view iType, std::string_view iOpti
 
     std::string fileName{iOptions};
     auto pos = fileName.find(':');
-    std::map<std::string, std::string> keyValues;
+    ConfigKeyValueMap keyValues;
     if(pos != std::string::npos) {
       auto remainingOptions = fileName.substr(pos+1);
       fileName = fileName.substr(0,pos);
@@ -178,7 +146,7 @@ cce::tf::outputerFactoryGenerator(std::string_view iType, std::string_view iOpti
     }
     keyValues["fileName"] = fileName;
 
-    outFactory = [keyValues](unsigned int nLanes) { return OutputerFactory::get()->create("PDSOutputer", nLanes, keyValues); };
+    outFactory = [params = ConfigurationParameters(keyValues)](unsigned int nLanes) { return OutputerFactory::get()->create("PDSOutputer", nLanes, params); };
     return outFactory;
   } else if(iType == "RootOutputer") {
     auto result = parseRootConfig(iOptions);
@@ -225,7 +193,7 @@ cce::tf::outputerFactoryGenerator(std::string_view iType, std::string_view iOpti
 
     std::string fileName{iOptions};
     auto pos = fileName.find(':');
-    std::map<std::string, std::string> keyValues;
+    ConfigKeyValueMap keyValues;
     if(pos != std::string::npos) {
       auto remainingOptions = fileName.substr(pos+1);
       fileName = fileName.substr(0,pos);
@@ -234,7 +202,7 @@ cce::tf::outputerFactoryGenerator(std::string_view iType, std::string_view iOpti
     }
     keyValues["fileName"] = fileName;
 
-    outFactory = [keyValues](unsigned int nLanes) { return OutputerFactory::get()->create("HDFOutputer", nLanes, keyValues); };
+    outFactory = [params=ConfigurationParameters(keyValues)](unsigned int nLanes) { return OutputerFactory::get()->create("HDFOutputer", nLanes, params); };
     return outFactory;
   } else if(iType == "TextDumpOutputer") {
     auto result = parseTextDumpConfig(iOptions);

--- a/sourceFactoryGenerator.cc
+++ b/sourceFactoryGenerator.cc
@@ -1,69 +1,33 @@
 #include "sourceFactoryGenerator.h"
-
-#include "RootSource.h"
-#include "RepeatingRootSource.h"
-#include "SerialRootSource.h"
-#include "PDSSource.h"
-#include "HDFSource.h"
-#include "SharedPDSSource.h"
-#include "EmptySource.h"
-#include "ReplicatedSharedSource.h"
-#include "TestProductsSource.h"
+#include "SourceFactory.h"
+#include "configKeyValuePairs.h"
+#include <iostream>
 
 std::function<std::unique_ptr<cce::tf::SharedSourceBase>(unsigned int, unsigned long long)> 
 cce::tf::sourceFactoryGenerator(std::string_view iType, std::string_view iOptions) {
   std::function<std::unique_ptr<SharedSourceBase>(unsigned int, unsigned long long)> sourceFactory;
-  if( iType == "ReplicatedRootSource") {
-    std::string fileName( iOptions );
-    sourceFactory = [fileName](unsigned int iNLanes, unsigned long long iNEvents) {
-      return std::make_unique<ReplicatedSharedSource<RootSource>>(iNLanes, iNEvents, fileName);
-    };
-  } else if( iType == "RepeatingRootSource") {
-    std::string fileName( iOptions );
-    unsigned int nUniqueEvents = 10;
-    std::string branchToRead;
-    auto pos = fileName.find(':');
-    if(pos != std::string::npos) {
-      nUniqueEvents = std::stoul(fileName.substr(pos+1));
-      auto leftOptions = fileName.substr(pos+1);
-      fileName = fileName.substr(0,pos);
-      pos = leftOptions.find(':', 0);
-      if(pos != std::string::npos) {
-        branchToRead = leftOptions.substr(pos+1);
+
+  auto keyValues = cce::tf::configKeyValuePairs(iOptions);
+  sourceFactory = [type = std::string(iType), params=ConfigurationParameters(keyValues)]
+    (unsigned int iNLanes, unsigned long long iNEvents) {
+    auto maker = SourceFactory::get()->create(type, iNLanes, iNEvents, params);
+    
+    if(not maker) {
+      return maker;
+    }
+    
+    //make sure all parameters given were used
+    auto unusedOptions = params.unusedKeys();
+    if(not unusedOptions.empty()) {
+      std::cout <<"Unused options in "<<type<<"\n";
+      for(auto const& key: unusedOptions) {
+        std::cout <<"  '"<<key<<"'"<<std::endl;
       }
+      return decltype(maker)();
     }
-    sourceFactory = [fileName, nUniqueEvents, branchToRead](unsigned int iNLanes, unsigned long long iNEvents) {
-      return std::make_unique<RepeatingRootSource>(fileName, nUniqueEvents, iNLanes, iNEvents, branchToRead);
-    };
-  } else if( iType == "SerialRootSource") {
-    std::string fileName( iOptions );
-    sourceFactory = [fileName](unsigned int iNLanes, unsigned long long iNEvents) {
-      return std::make_unique<SerialRootSource>(iNLanes, iNEvents, fileName);
-    };    
-  } else if( iType == "ReplicatedPDSSource") {
-    std::string fileName( iOptions );
-    sourceFactory = [fileName](unsigned int iNLanes, unsigned long long iNEvents) {
-      return std::make_unique<ReplicatedSharedSource<PDSSource>>(iNLanes, iNEvents, fileName);
-    };
-  } else if( iType == "SharedPDSSource") {
-    std::string fileName( iOptions );
-    sourceFactory = [fileName](unsigned int iNLanes, unsigned long long iNEvents) {
-      return std::make_unique<SharedPDSSource>(iNLanes, iNEvents, fileName);
-    };
-  } else if( iType == "EmptySource") {
-    sourceFactory = [](unsigned int iNLanes, unsigned long long iNEvents) {
-      return std::make_unique<EmptySource>(iNEvents);
-      };
-    }
-    else if( iType == "HDFSource") {
-      std::string fileName( iOptions );
-      sourceFactory = [fileName](unsigned int iNLanes, unsigned long long iNEvents) {
-        return std::make_unique<ReplicatedSharedSource<HDFSource>>(iNLanes, iNEvents, fileName);
-      };
-  } else if(iType == "TestProductsSource") {
-    sourceFactory = [](unsigned int iNLanes, unsigned long long iNEvents) {
-      return std::make_unique<TestProductsSource>(iNLanes, iNEvents);
-    };
-  }
+    
+    return maker;
+  };
+
   return sourceFactory;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
-add_executable(doTests test_main.cc test_configKeyValuePairs.cc)
+add_executable(doTests test_main.cc test_configKeyValuePairs.cc test_ConfigurationParameters.cc)
 
 target_include_directories(doTests PUBLIC "${PROJECT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/..")
-target_link_libraries(doTests PUBLIC configKeys)
+target_link_libraries(doTests PUBLIC configKeys configParams)
 
 add_test (NAME RunTests COMMAND doTests)

--- a/tests/test_ConfigurationParameters.cc
+++ b/tests/test_ConfigurationParameters.cc
@@ -1,0 +1,92 @@
+#include "catch2/catch.hpp"
+#include "ConfigurationParameters.h"
+
+TEST_CASE("Test ConfigurationParameters class", "[ConfigurationParameters]") {
+  using namespace cce::tf;
+
+  SECTION("empty configuration") {
+    ConfigurationParameters::KeyValueMap map;
+    ConfigurationParameters params(map);
+    SECTION("unusedKeys") {
+      REQUIRE(params.unusedKeys().empty());
+    }
+    SECTION("get with out default") {
+      REQUIRE(not params.get<int>("foo"));
+      REQUIRE(not params.get<std::string>("foo"));
+      REQUIRE(not params.get<unsigned int>("foo"));
+      REQUIRE(not params.get<bool>("foo"));
+    }
+    SECTION("defaults for missing parameters") {
+      REQUIRE(params.get<int>("foo", 1) == 1);
+      REQUIRE(params.get<unsigned int>("foo", 10) == 10);
+      REQUIRE(params.get<std::string>("foo","bar") == "bar");
+      REQUIRE(params.get<bool>("foo",true));
+      REQUIRE(not params.get<bool>("foo", false));
+    }
+  }
+
+
+  SECTION("string param") {
+    ConfigurationParameters::KeyValueMap map = {{"foo", "bar"}};
+    ConfigurationParameters params(map);
+    REQUIRE(params.unusedKeys().size() == 1);
+    REQUIRE(params.get<std::string>("foo") == "bar");
+    REQUIRE(params.get<std::string>("foo", "blah") == "bar");
+    REQUIRE(params.unusedKeys().empty());
+  }
+
+  SECTION("int param") {
+    ConfigurationParameters::KeyValueMap map = {{"foo", "-3"}};
+    ConfigurationParameters params(map);
+    REQUIRE(params.unusedKeys().size() == 1);
+    REQUIRE(params.get<int>("foo") == -3);
+    REQUIRE(params.get<int>("foo", 1) == -3);
+    REQUIRE(params.unusedKeys().empty());
+  }
+
+  SECTION("unsigned int param") {
+    ConfigurationParameters::KeyValueMap map = {{"foo", "5"}};
+    ConfigurationParameters params(map);
+    REQUIRE(params.unusedKeys().size() == 1);
+    REQUIRE(params.get<unsigned int>("foo") == 5);
+    REQUIRE(params.get<unsigned int>("foo", 1) == 5);
+    REQUIRE(params.unusedKeys().empty());
+  }
+
+  SECTION("bool param") {
+    SECTION("true") {
+      ConfigurationParameters::KeyValueMap map = {{"a", "T"}, {"b", "t"}, {"c", "Y"}, {"d", "y"}, {"e",""}, 
+                                                  {"f", "TRUE"}, {"g", "True"}, {"h", "true"},
+                                                  {"i", "YES"}, {"j", "Yes"}, {"k", "yes"}};
+      ConfigurationParameters params(map);
+      REQUIRE(*params.get<bool>("a"));
+      REQUIRE(*params.get<bool>("b"));
+      REQUIRE(*params.get<bool>("c"));
+      REQUIRE(*params.get<bool>("d"));
+      REQUIRE(*params.get<bool>("e"));
+      REQUIRE(*params.get<bool>("f"));
+      REQUIRE(*params.get<bool>("g"));
+      REQUIRE(*params.get<bool>("h"));
+      REQUIRE(*params.get<bool>("i"));
+      REQUIRE(*params.get<bool>("j"));
+      REQUIRE(*params.get<bool>("k"));
+    }
+    SECTION("false") {
+      ConfigurationParameters::KeyValueMap map = {{"a", "F"}, {"b", "f"}, {"c", "N"}, {"d", "n"}, 
+                                                  {"f", "FALSE"}, {"g", "False"}, {"h", "false"},
+                                                  {"i", "NO"}, {"j", "No"}, {"k", "no"}};
+      ConfigurationParameters params(map);
+      REQUIRE(not *params.get<bool>("a"));
+      REQUIRE(not *params.get<bool>("b"));
+      REQUIRE(not *params.get<bool>("c"));
+      REQUIRE(not *params.get<bool>("d"));
+      REQUIRE(not *params.get<bool>("f"));
+      REQUIRE(not *params.get<bool>("g"));
+      REQUIRE(not *params.get<bool>("h"));
+      REQUIRE(not *params.get<bool>("i"));
+      REQUIRE(not *params.get<bool>("j"));
+      REQUIRE(not *params.get<bool>("k"));
+    }
+  }
+
+}

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -119,6 +119,10 @@ int main(int argc, char* argv[]) {
       return 1;
     }
     auto source =sourceFactory(1,1);
+    if(not source) {
+      std::cout <<"failed to create source\n";
+      return 1;
+    }
     Lane lane(0, source.get(), 0);
     out->setupForLane(0, lane.dataProducts());
     auto pOut = out.get();

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -110,15 +110,19 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  std::cout <<"begin warmup"<<std::endl;
   {
     //warm up the system by processing 1 event 
     tbb::task_arena arena(1);
     auto out = outFactory(1);
+    if(not out) {
+      std::cout <<"failed to create outputer\n";
+      return 1;
+    }
     auto source =sourceFactory(1,1);
     Lane lane(0, source.get(), 0);
     out->setupForLane(0, lane.dataProducts());
     auto pOut = out.get();
+    std::cout <<"begin warmup"<<std::endl;
     arena.execute([&lane,pOut]() {
         tbb::task_group group;
         std::atomic<long> ievt{0};


### PR DESCRIPTION
This is a first draft for making it easier to add new Outputers and Sources to the job. Instead of having to edit the appropriate *Factory function, one just instantiates the appropriate `Maker` for the appropriate `Factory` and then makes sure the .o file containing the instance is linked with the executable.