### PR TITLE
Added per Event ROOT storage format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ add_executable(threaded_io_test
   RootOutputer.cc
   RootSource.cc
   SerialRootSource.cc
+  RootEventOutputer.cc
+  SharedRootEventSource.cc
   SerialTaskQueue.cc
   SerializeStrategy.cc
   SharedPDSSource.cc
@@ -123,6 +125,7 @@ add_test(NAME PDSOutputerEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10
 add_test(NAME TestProductsPDS COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 PDSOutputer=test_prod.pds; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SharedPDSSource=test_prod.pds 1 1 0 10 TestProductsOutputer")
 add_test(NAME PDSOutputerAllOptionsEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 PDSOutputer=test_empty.pds:compressionLevel=8:compressionAlgorithm=LZ4:serializationAlgorithm=Unrolled)
 add_test(NAME TestProductsPDSUnrolled COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 PDSOutputer=test_prod_unroll.pds:serializationAlgorithm=Unrolled; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SharedPDSSource=test_prod_unroll.pds 1 1 0 10 TestProductsOutputer")
+add_test(NAME TestProductsPDSUncompressed COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 PDSOutputer=test_prod.pds:compressionAlgorithm=None; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SharedPDSSource=test_prod.pds 1 1 0 10 TestProductsOutputer")
 add_test(NAME RootOutputerEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootOutputer=test_empty.root)
 add_test(NAME RootOutputerEmptySplitLevelTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootOutputer=test_empty.root:splitLevel=1)
 add_test(NAME RootOutputerEmptyAllOptionsTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootOutputer=test_empty.root:splitLevel=1:compressionLevel=1:compressionAlgorithm=LZMA:basketSize=32000:treeMaxVirtualSize=-1:autoFlush=900)
@@ -130,6 +133,13 @@ add_test(NAME TestProductsROOT COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/thre
 add_test(NAME TestProductsROOTReplicated COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_repl.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test ReplicatedRootSource=test_prod_repl.root 1 1 0 10 TestProductsOutputer")
 add_test(NAME TestProductsROOTRepeating COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_rep.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test RepeatingRootSource=test_prod_rep.root:repeat=5 1 1 0 100 TestProductsOutputer")
 add_test(NAME TestProductsROOTRepeatingOneBranch COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootOutputer=test_prod_rep_1branch.root; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test RepeatingRootSource=test_prod_rep_1branch.root:repeat=5:branchToRead=floats 1 1 0 100 TestProductsOutputer")
+
+add_test(NAME RootEventOutputerEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootEventOutputer=test_empty.eroot)
+add_test(NAME TestProductsRootEvent COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootEventOutputer=test_prod.eroot; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SharedRootEventSource=test_prod.eroot 1 1 0 10 TestProductsOutputer")
+add_test(NAME RootEventOutputerAllOptionsEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 RootEventOutputer=test_empty.eroot:compressionLevel=8:compressionAlgorithm=LZ4:serializationAlgorithm=Unrolled)
+add_test(NAME TestProductsRootEventUnrolled COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test TestProductsSource 1 1 0 10 RootEventOutputer=test_prod_unroll.eroot:serializationAlgorithm=Unrolled; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test SharedRootEventSource=test_prod_unroll.eroot 1 1 0 10 TestProductsOutputer")
+
+
 add_test(NAME TBufferMergerRootOutputerEmptyTest COMMAND threaded_io_test EmptySource 1 1 0 10 TBufferMergerRootOutputer=test_empty.root)
 add_test(NAME TBufferMergerRootOutputerEmptySplitLevelTest COMMAND threaded_io_test EmptySource 1 1 0 10 TBufferMergerRootOutputer=test_empty.root:splitLevel=1)
 add_test(NAME TBufferMergerRootOutputerEmptyAllOptionsTest COMMAND threaded_io_test EmptySource 1 1 0 10 TBufferMergerRootOutputer=test_empty.root:splitLevel=1:compressionLevel=1:compressionAlgorithm=LZMA:basketSize=32000:treeMaxVirtualSize=-1:autoFlush=900)

--- a/PDSOutputer.cc
+++ b/PDSOutputer.cc
@@ -270,7 +270,7 @@ std::vector<uint32_t> PDSOutputer::lz4CompressBuffer(unsigned int iLeadPadding, 
 
 std::vector<uint32_t> PDSOutputer::noCompressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<uint32_t> const& iBuffer, int& cSize) const {
   auto const bound = iBuffer.size()*4;
-  std::vector<uint32_t> cBuffer(bytesToWords(size_t(bound))+iLeadPadding+iTrailingPadding, 0);
+  std::vector<uint32_t> cBuffer(iBuffer.size()+iLeadPadding+iTrailingPadding, uint32_t(0));
   cSize = bound;
   std::copy(iBuffer.begin(), iBuffer.end(), cBuffer.begin()+iLeadPadding);
   return cBuffer;

--- a/PDSSource.cc
+++ b/PDSSource.cc
@@ -28,6 +28,8 @@ bool PDSSource::readEventContent() {
   if(not readCompressedEventBuffer(file_, eventID_, buffer)) {
     return false;
   }
+  //last entry in buffer is a crosscheck on its size
+  buffer.pop_back();
   std::vector<uint32_t> uBuffer = uncompressEventBuffer(compression_, buffer);
   deserializeDataProducts(uBuffer.begin(), uBuffer.end(), dataProducts_, deserializers_);
 

--- a/RootEventOutputer.cc
+++ b/RootEventOutputer.cc
@@ -1,0 +1,287 @@
+#include "RootEventOutputer.h"
+#include "OutputerFactory.h"
+#include "ConfigurationParameters.h"
+#include "UnrolledSerializerWrapper.h"
+#include "SerializerWrapper.h"
+#include "summarize_serializers.h"
+#include "lz4.h"
+#include "zstd.h"
+#include <iostream>
+#include <cstring>
+#include <set>
+
+using namespace cce::tf;
+
+RootEventOutputer::RootEventOutputer(std::string const& iFileName, unsigned int iNLanes, Compression iCompression, int iCompressionLevel, 
+                                     Serialization iSerialization ): 
+  file_(iFileName.c_str(), "recreate", "", 0),
+  serializers_{std::size_t(iNLanes)},
+  compression_{iCompression},
+  compressionLevel_{iCompressionLevel},
+  serialization_{iSerialization},
+  serialTime_{std::chrono::microseconds::zero()},
+  parallelTime_{0}
+  {
+    //gDebug = 3;
+    eventsTree_ = new TTree("Events", "", 0, &file_);
+
+    eventsTree_->Branch("blob", &eventBlob_);
+    eventsTree_->Branch("EventID", &eventID_, "run/i:lumi/i:event/l");
+}
+
+RootEventOutputer::~RootEventOutputer() {
+  file_.Write();
+  file_.Close();
+}
+
+
+void RootEventOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProductRetriever> const& iDPs) {
+  auto& s = serializers_[iLaneIndex];
+  switch(serialization_) {
+  case Serialization::kRoot:
+    {   s = SerializeStrategy::make<SerializeProxy<SerializerWrapper>>(); break; }
+  case Serialization::kRootUnrolled:
+    {   s = SerializeStrategy::make<SerializeProxy<UnrolledSerializerWrapper>>(); break; }
+  }
+  s.reserve(iDPs.size());
+  for(auto const& dp: iDPs) {
+    s.emplace_back(dp.name(), dp.classType());
+  }
+}
+
+void RootEventOutputer::productReadyAsync(unsigned int iLaneIndex, DataProductRetriever const& iDataProduct, TaskHolder iCallback) const {
+  auto& laneSerializers = serializers_[iLaneIndex];
+  auto group = iCallback.group();
+  laneSerializers[iDataProduct.index()].doWorkAsync(*group, iDataProduct.address(), std::move(iCallback));
+}
+
+void RootEventOutputer::outputAsync(unsigned int iLaneIndex, EventIdentifier const& iEventID, TaskHolder iCallback) const {
+  auto start = std::chrono::high_resolution_clock::now();
+  auto tempBuffer = std::make_unique<std::vector<uint32_t>>(writeDataProductsToOutputBuffer(serializers_[iLaneIndex]));
+  queue_.push(*iCallback.group(), [this, iEventID, iLaneIndex, callback=std::move(iCallback), buffer=std::move(tempBuffer)]() mutable {
+      auto start = std::chrono::high_resolution_clock::now();
+      const_cast<RootEventOutputer*>(this)->output(iEventID, serializers_[iLaneIndex],*buffer);
+      buffer.reset();
+        serialTime_ += std::chrono::duration_cast<decltype(serialTime_)>(std::chrono::high_resolution_clock::now() - start);
+      callback.doneWaiting();
+    });
+    auto time = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start);
+    parallelTime_ += time.count();
+}
+
+void RootEventOutputer::printSummary() const  {
+  std::cout <<"RootEventOutputer\n  total serial time at end event: "<<serialTime_.count()<<"us\n"
+    "  total parallel time at end event: "<<parallelTime_.load()<<"us\n";
+  summarize_serializers(serializers_);
+}
+
+
+
+void RootEventOutputer::output(EventIdentifier const& iEventID, SerializeStrategy const& iSerializers, std::vector<uint32_t>const& iBuffer) {
+  if(firstTime_) {
+    writeMetaData(iSerializers);
+    firstTime_ = false;
+  }
+  //using namespace std::string_literals;
+  
+  //std::cout <<"   run:"s+std::to_string(iEventID.run)+" lumi:"s+std::to_string(iEventID.lumi)+" event:"s+std::to_string(iEventID.event)+"\n"<<std::flush;
+  
+  //writeEventID(iEventID);
+  eventID_ = iEventID;
+  eventBlob_ = std::move(iBuffer);
+  //std::cout <<"Event "<<eventID_.run<<" "<<eventID_.lumi<<" "<<eventID_.event<<std::endl;
+  //std::cout <<"buffer size "<<eventBlob_.size();
+  //for(auto b: eventBlob_) {
+  //  std::cout <<"   "<<b<<std::endl;
+  //}
+  eventsTree_->Fill();
+  /*
+    for(auto& s: iSerializers) {
+    std::cout<<"   "s+s.name()+" size "+std::to_string(s.blob().size())+"\n" <<std::flush;
+    }
+  */
+}
+
+void RootEventOutputer::writeMetaData(SerializeStrategy const& iSerializers) {
+
+  std::vector<std::pair<std::string, std::string>> typeAndNames;
+  for(auto const& s: iSerializers) {
+    std::string type(s.className());
+    std::string name(s.name());
+    typeAndNames.emplace_back(std::move(type), std::move(name));
+  }
+
+  int objectSerializationUsed = static_cast<std::underlying_type_t<Serialization>>(serialization_);
+
+
+  std::string compression;
+  {
+    //Compression type used
+    // note want exactly 4 bytes so sometimes skip trailing \0
+    switch(compression_) {
+    case Compression::kNone:
+      {
+        compression = "None";
+	break;
+      }
+    case Compression::kLZ4:
+      {
+        compression = "LZ4";
+	break;
+      }
+    case Compression::kZSTD:
+      {
+        compression = "ZSTD";
+	break;
+      }
+    }
+  }
+
+  TTree* meta = new TTree("Meta", "File meta data", 0, &file_);
+  meta->Branch("DataProducts",&typeAndNames, 0, 0);
+  meta->Branch("objectSerializationUsed",&objectSerializationUsed);
+  meta->Branch("compressionAlgorithm",&compression,0,0);
+
+  meta->Fill();
+
+}
+
+std::vector<uint32_t> RootEventOutputer::writeDataProductsToOutputBuffer(SerializeStrategy const& iSerializers) const{
+  //Calculate buffer size needed
+  uint32_t bufferSize = 0;
+  for(auto const& s: iSerializers) {
+    bufferSize +=1+1;
+    auto const blobSize = s.blob().size();
+    bufferSize += bytesToWords(blobSize); //handles padding
+  }
+  //initialize with 0
+  std::vector<uint32_t> buffer(size_t(bufferSize), 0);
+  
+  {
+    uint32_t bufferIndex = 0;
+    uint32_t dataProductIndex = 0;
+    for(auto const& s: iSerializers) {
+      //std::cout <<"  write: "<<s.name()<<std::endl;
+      buffer[bufferIndex++]=dataProductIndex++;
+      auto const blobSize = s.blob().size();
+      uint32_t sizeInWords = bytesToWords(blobSize);
+      buffer[bufferIndex++]=sizeInWords;
+      std::copy(s.blob().begin(), s.blob().end(), reinterpret_cast<char*>( &(*(buffer.begin()+bufferIndex)) ) );
+      bufferIndex += sizeInWords;
+    }
+    assert(buffer.size() == bufferIndex);
+  }
+  int cSize;
+  std::vector<uint32_t> cBuffer = compressBuffer(2, 1, buffer, cSize);
+
+  //std::cout <<"compressed "<<cSize<<" uncompressed "<<buffer.size()*4<<std::endl;
+  //std::cout <<"compressed "<<(buffer.size()*4)/float(cSize)<<std::endl;
+  uint32_t const recordSize = bytesToWords(cSize)+1;
+  cBuffer[0] = recordSize;
+  //Record the actual number of bytes used in the last word of the compression buffer in the lowest
+  // 2 bits of the word
+  cBuffer[1] = buffer.size()*4 + (cSize % 4);
+  if(cBuffer.size() != recordSize+2) {
+    std::cout <<"BAD BUFFER SIZE: want: "<<recordSize+2<<" got "<<cBuffer.size()<<std::endl;
+  }
+  assert(cBuffer.size() == recordSize+2);
+  cBuffer[recordSize+1]=recordSize;
+  return cBuffer;
+}
+
+std::vector<uint32_t> RootEventOutputer::compressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<uint32_t> const& iBuffer, int& oCompressedSize) const {
+  switch(compression_) {
+  case Compression::kLZ4 : {
+      return lz4CompressBuffer(iLeadPadding,iTrailingPadding, iBuffer, oCompressedSize);
+    }    
+  case Compression::kNone : {
+      return noCompressBuffer(iLeadPadding, iTrailingPadding, iBuffer, oCompressedSize);
+    } 
+  case Compression::kZSTD : {
+      return zstdCompressBuffer(iLeadPadding, iTrailingPadding, iBuffer, oCompressedSize);
+    }
+  default:
+    return noCompressBuffer(iLeadPadding, iTrailingPadding, iBuffer, oCompressedSize);
+  };
+}
+
+
+std::vector<uint32_t> RootEventOutputer::lz4CompressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<uint32_t> const& iBuffer, int& cSize) const {
+  auto const bound = LZ4_compressBound(iBuffer.size()*4);
+  std::vector<uint32_t> cBuffer(bytesToWords(size_t(bound))+iLeadPadding+iTrailingPadding, 0);
+  cSize = LZ4_compress_default(reinterpret_cast<char const*>(&(*iBuffer.begin())), reinterpret_cast<char*>(&(*(cBuffer.begin()+iLeadPadding))), iBuffer.size()*4, bound);
+  cBuffer.resize(bytesToWords(cSize)+iLeadPadding+iTrailingPadding);
+  return cBuffer;
+}
+
+std::vector<uint32_t> RootEventOutputer::noCompressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<uint32_t> const& iBuffer, int& cSize) const {
+  auto const bound = iBuffer.size()*4;
+  std::vector<uint32_t> cBuffer(bytesToWords(size_t(bound))+iLeadPadding+iTrailingPadding, 0);
+  cSize = bound;
+  std::copy(iBuffer.begin(), iBuffer.end(), cBuffer.begin()+iLeadPadding);
+  return cBuffer;
+}
+
+std::vector<uint32_t> RootEventOutputer::zstdCompressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<uint32_t> const& iBuffer, int& cSize) const {
+  auto const bound = ZSTD_compressBound(iBuffer.size()*4);
+  std::vector<uint32_t> cBuffer(bytesToWords(size_t(bound))+iLeadPadding+iTrailingPadding, 0);
+  cSize = ZSTD_compress(&(*(cBuffer.begin()+iLeadPadding)), bound, &(*iBuffer.begin()),  iBuffer.size()*4, compressionLevel_);
+  if(ZSTD_isError(cSize)) {
+    std::cout <<"ERROR in comparession "<<ZSTD_getErrorName(cSize)<<std::endl;
+  }
+  cBuffer.resize(bytesToWords(cSize)+iLeadPadding+iTrailingPadding);
+  return cBuffer;
+}
+
+namespace {
+
+  class PDSMaker : public OutputerMakerBase {
+  public:
+    PDSMaker(): OutputerMakerBase("RootEventOutputer") {}
+
+    std::unique_ptr<OutputerBase> create(unsigned int iNLanes, ConfigurationParameters const& params) const final {
+
+      auto fileName = params.get<std::string>("fileName");
+      if(not fileName) {
+        std::cout <<"no file name given for RootEventOutputer\n";
+        return {};
+      }
+
+      int compressionLevel = params.get<int>("compressionLevel", 18);
+
+      auto compressionName = params.get<std::string>("compressionAlgorithm", "ZSTD");
+      auto serializationName = params.get<std::string>("serializationAlgorithm", "ROOT");
+
+      RootEventOutputer::Compression compression = RootEventOutputer::Compression::kZSTD;
+
+      if(compressionName == "" or compressionName =="None") {
+        compression = RootEventOutputer::Compression::kNone;
+      } else if (compressionName == "LZ4") {
+        compression = RootEventOutputer::Compression::kLZ4;
+      } else if (compressionName == "ZSTD") {
+      compression = RootEventOutputer::Compression::kZSTD;
+      } else {
+        std::cout <<"unknown compression "<<compressionName<<std::endl;
+        return {};
+      }
+
+      RootEventOutputer::Serialization serialization = RootEventOutputer::Serialization::kRoot;
+
+      if(serializationName == "" or serializationName=="ROOT") {
+        serialization = RootEventOutputer::Serialization::kRoot;
+      } else if(serializationName == "ROOTUnrolled" or serializationName=="Unrolled") {
+        serialization = RootEventOutputer::Serialization::kRootUnrolled;
+      } else {
+        std::cout <<"unknown serialization "<<serializationName<<std::endl;
+        return {};
+      }
+      
+      return std::make_unique<RootEventOutputer>(*fileName,iNLanes, compression, compressionLevel, serialization);
+    }
+    
+  };
+
+  PDSMaker s_maker;
+}
+
+

--- a/RootEventOutputer.cc
+++ b/RootEventOutputer.cc
@@ -192,20 +192,18 @@ std::vector<uint32_t> RootEventOutputer::writeDataProductsToOutputBuffer(Seriali
     assert(buffer.size() == bufferIndex);
   }
   int cSize;
-  std::vector<uint32_t> cBuffer = compressBuffer(2, 1, buffer, cSize);
+  std::vector<uint32_t> cBuffer = compressBuffer(1, 0, buffer, cSize);
 
   //std::cout <<"compressed "<<cSize<<" uncompressed "<<buffer.size()*4<<std::endl;
   //std::cout <<"compressed "<<(buffer.size()*4)/float(cSize)<<std::endl;
   uint32_t const recordSize = bytesToWords(cSize)+1;
-  cBuffer[0] = recordSize;
   //Record the actual number of bytes used in the last word of the compression buffer in the lowest
   // 2 bits of the word
-  cBuffer[1] = buffer.size()*4 + (cSize % 4);
-  if(cBuffer.size() != recordSize+2) {
-    std::cout <<"BAD BUFFER SIZE: want: "<<recordSize+2<<" got "<<cBuffer.size()<<std::endl;
+  cBuffer[0] = buffer.size()*4 + (cSize % 4);
+  if(cBuffer.size() != recordSize+1) {
+    std::cout <<"BAD BUFFER SIZE: want: "<<recordSize+1<<" got "<<cBuffer.size()<<std::endl;
   }
-  assert(cBuffer.size() == recordSize+2);
-  cBuffer[recordSize+1]=recordSize;
+  assert(cBuffer.size() == recordSize+1);
   return cBuffer;
 }
 

--- a/RootEventOutputer.cc
+++ b/RootEventOutputer.cc
@@ -40,8 +40,6 @@ RootEventOutputer::RootEventOutputer(std::string const& iFileName, unsigned int 
 }
 
 RootEventOutputer::~RootEventOutputer() {
-  file_.Write();
-  file_.Close();
 }
 
 
@@ -82,6 +80,18 @@ void RootEventOutputer::outputAsync(unsigned int iLaneIndex, EventIdentifier con
 void RootEventOutputer::printSummary() const  {
   std::cout <<"RootEventOutputer\n  total serial time at end event: "<<serialTime_.count()<<"us\n"
     "  total parallel time at end event: "<<parallelTime_.load()<<"us\n";
+
+  auto start = std::chrono::high_resolution_clock::now();
+  file_.Write();
+  auto writeTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start);
+
+  start = std::chrono::high_resolution_clock::now();
+  file_.Close();
+  auto closeTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - start);
+
+  std::cout << "  end of job file write time: "<<writeTime.count()<<"us\n";
+  std::cout << "  end of job file close time: "<<closeTime.count()<<"us\n";
+                                                                                         
   summarize_serializers(serializers_);
 }
 

--- a/RootEventOutputer.h
+++ b/RootEventOutputer.h
@@ -21,7 +21,7 @@ class RootEventOutputer :public OutputerBase {
   enum class Compression {kNone, kLZ4, kZSTD};
   enum class Serialization {kRoot, kRootUnrolled};
  RootEventOutputer(std::string const& iFileName, unsigned int iNLanes, Compression iCompression, int iCompressionLevel, 
-                   Serialization iSerialization );
+                   Serialization iSerialization, int autoFlush, int maxVirtualSize );
  ~RootEventOutputer();
 
   void setupForLane(unsigned int iLaneIndex, std::vector<DataProductRetriever> const& iDPs) final;

--- a/RootEventOutputer.h
+++ b/RootEventOutputer.h
@@ -50,7 +50,7 @@ class RootEventOutputer :public OutputerBase {
   std::vector<uint32_t> noCompressBuffer(unsigned int iReserveFirstNWords, unsigned int iPadding, std::vector<uint32_t> const& iBuffer, int& oCompressedSize) const;
 
 private:
-  TFile file_;
+  mutable TFile file_;
 
   TTree* eventsTree_;
 

--- a/RootEventOutputer.h
+++ b/RootEventOutputer.h
@@ -1,0 +1,69 @@
+#if !defined(RootEventOutputer_h)
+#define RootEventOutputer_h
+
+#include <vector>
+#include <string>
+#include <cstdint>
+#include "TFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+
+#include "OutputerBase.h"
+#include "EventIdentifier.h"
+#include "SerializeStrategy.h"
+#include "DataProductRetriever.h"
+
+#include "SerialTaskQueue.h"
+
+namespace cce::tf {
+class RootEventOutputer :public OutputerBase {
+ public:
+  enum class Compression {kNone, kLZ4, kZSTD};
+  enum class Serialization {kRoot, kRootUnrolled};
+ RootEventOutputer(std::string const& iFileName, unsigned int iNLanes, Compression iCompression, int iCompressionLevel, 
+                   Serialization iSerialization );
+ ~RootEventOutputer();
+
+  void setupForLane(unsigned int iLaneIndex, std::vector<DataProductRetriever> const& iDPs) final;
+
+  void productReadyAsync(unsigned int iLaneIndex, DataProductRetriever const& iDataProduct, TaskHolder iCallback) const final;
+  bool usesProductReadyAsync() const final {return true;}
+
+  void outputAsync(unsigned int iLaneIndex, EventIdentifier const& iEventID, TaskHolder iCallback) const final;
+  
+  void printSummary() const final;
+
+ private:
+  static inline size_t bytesToWords(size_t nBytes) {
+    return nBytes/4 + ( (nBytes % 4) == 0 ? 0 : 1);
+  }
+
+  void output(EventIdentifier const& iEventID, SerializeStrategy const& iSerializers, std::vector<uint32_t> const& iBuffer);
+  void writeMetaData(SerializeStrategy const& iSerializers);
+
+  std::vector<uint32_t> writeDataProductsToOutputBuffer(SerializeStrategy const& iSerializers) const;
+
+  std::vector<uint32_t> compressBuffer(unsigned int iReserveFirstNWords, unsigned int iPadding, std::vector<uint32_t> const& iBuffer, int& oCompressedSize) const;
+
+  std::vector<uint32_t> lz4CompressBuffer(unsigned int iReserveFirstNWords, unsigned int iPadding, std::vector<uint32_t> const& iBuffer, int& oCompressedSize) const;
+  std::vector<uint32_t> zstdCompressBuffer(unsigned int iReserveFirstNWords, unsigned int iPadding, std::vector<uint32_t> const& iBuffer, int& oCompressedSize) const;
+  std::vector<uint32_t> noCompressBuffer(unsigned int iReserveFirstNWords, unsigned int iPadding, std::vector<uint32_t> const& iBuffer, int& oCompressedSize) const;
+
+private:
+  TFile file_;
+
+  TTree* eventsTree_;
+
+  mutable SerialTaskQueue queue_;
+  mutable std::vector<SerializeStrategy> serializers_;
+  mutable std::vector<uint32_t> eventBlob_;
+  EventIdentifier eventID_;
+  Compression compression_;
+  int compressionLevel_;
+  Serialization serialization_;
+  bool firstTime_ = true;
+  mutable std::chrono::microseconds serialTime_;
+  mutable std::atomic<std::chrono::microseconds::rep> parallelTime_;
+};
+}
+#endif

--- a/SharedPDSSource.cc
+++ b/SharedPDSSource.cc
@@ -80,6 +80,8 @@ void SharedPDSSource::readEventAsync(unsigned int iLane, long iEventIndex,  Opti
       std::vector<uint32_t> buffer;
       
       if(pds::readCompressedEventBuffer(file_, this->laneInfos_[iLane].eventID_, buffer)) {
+        //last entry in buffer is just a crosscheck on its size
+        buffer.pop_back();
         auto group = optTask.group();
         group->run([this, buffer=std::move(buffer), task = optTask.releaseToTaskHolder(), iLane]() {
             auto& laneInfo = this->laneInfos_[iLane];

--- a/SharedRootEventSource.cc
+++ b/SharedRootEventSource.cc
@@ -183,7 +183,6 @@ void SharedRootEventSource::readEventAsync(unsigned int iLane, long iEventIndex,
           //}
         }
 
-        buffer.erase(buffer.begin());
         auto group = optTask.group();
         group->run([this, buffer=std::move(buffer), task = optTask.releaseToTaskHolder(), iLane]() {
             auto& laneInfo = this->laneInfos_[iLane];

--- a/SharedRootEventSource.cc
+++ b/SharedRootEventSource.cc
@@ -1,0 +1,251 @@
+#include "SharedRootEventSource.h"
+#include "SourceFactory.h"
+#include "Deserializer.h"
+#include "UnrolledDeserializer.h"
+
+#include "TClass.h"
+
+using namespace cce::tf;
+
+SharedRootEventSource::SharedRootEventSource(unsigned int iNLanes, unsigned long long iNEvents, std::string const& iName) :
+                 SharedSourceBase(iNEvents),
+                 file_{TFile::Open(iName.c_str())},
+  readTime_{std::chrono::microseconds::zero()}
+{
+
+  //gDebug = 3;
+
+  if(not file_) {
+    std::cout <<"unknown file "<<iName<<std::endl;
+    throw std::runtime_error("uknown file");
+  }
+
+  eventsTree_ = file_->Get<TTree>("Events");
+  if(not eventsTree_) {
+    std::cout <<"no Events TTree in file "<<iName<<std::endl;
+    throw std::runtime_error("no Events TTree");
+  }
+  eventsBranch_ = eventsTree_->GetBranch("blob");
+  if( not eventsBranch_) {
+    std::cout <<"no 'blob' TBranch in 'Events' TTree in file "<<iName<<std::endl;
+    throw std::runtime_error("no 'blob' TBranch");
+  }
+
+  idBranch_ = eventsTree_->GetBranch("EventID");
+  if(not idBranch_) {
+    std::cout <<"no 'EventID' TBranch in 'Events' TTree in file "<<iName<<std::endl;
+    throw std::runtime_error("no 'EventID' TBranch");
+  }
+   
+  auto meta = file_->Get<TTree>("Meta");
+  if(not meta) {
+    std::cout <<"no 'Meta' TTree in file "<<iName<<std::endl;
+    throw std::runtime_error("no 'Meta' TTree");
+  }
+
+  std::vector<std::pair<std::string, std::string>> typeAndNames;
+  int objectSerializationUsed;
+  std::string compression;
+
+  {
+    auto typeAndNamesBranch = meta->GetBranch("DataProducts");
+    auto pTemp = &typeAndNames;
+    typeAndNamesBranch->SetAddress(&pTemp);
+    typeAndNamesBranch->GetEntry(0);
+
+    //std::cout <<"typeAndNames.size() "<<typeAndNames.size()<<std::endl;
+    //for(auto const& tn: typeAndNames) {
+    //  std::cout <<"  "<<tn.first<<" "<<tn.second<<std::endl;
+    //}
+    
+  }
+  {
+    auto serializerBranch = meta->GetBranch("objectSerializationUsed");
+    serializerBranch->SetAddress(&objectSerializationUsed);
+    serializerBranch->GetEntry(0);
+
+    //std::cout <<"serialization "<<objectSerializationUsed<<std::endl;
+  }
+  {
+    auto compressionBranch = meta->GetBranch("compressionAlgorithm");
+    auto pTemp = &compression;
+    compressionBranch->SetAddress(&pTemp);
+    compressionBranch->GetEntry(0);
+    //std::cout <<"compressionAlgorithm "<<compression<<std::endl;
+  }
+
+  pds::Serialization serialization;
+  switch(objectSerializationUsed) {
+  case static_cast<int>(pds::Serialization::kRoot):
+    serialization = pds::Serialization::kRoot;
+    break;
+  case static_cast<int>(pds::Serialization::kRootUnrolled):
+    serialization = pds::Serialization::kRootUnrolled;
+    break;
+  }
+
+  if (compression == "None") {
+    compression_ = pds::Compression::kNone;
+  }else if (compression == "LZ4") {
+    compression_ = pds::Compression::kLZ4;
+  }else if (compression == "ZSTD") {
+    compression_ = pds::Compression::kZSTD;
+  } else {
+    std::cout <<"Unknown compression algorithm '"<<compression<<"'"<<std::endl;
+    throw std::runtime_error("unknown compression algorithm");
+  }
+
+  std::vector<pds::ProductInfo> productInfo;
+  productInfo.reserve(typeAndNames.size());
+  { 
+    unsigned int index = 0;
+    for( auto const& typeAndName: typeAndNames) {
+      productInfo.emplace_back(typeAndName.second, index++, typeAndName.first);
+    }
+  }
+
+  laneInfos_.reserve(iNLanes);
+  for(unsigned int i = 0; i< iNLanes; ++i) {
+    DeserializeStrategy strategy;
+    switch(serialization) {
+    case pds::Serialization::kRoot: { 
+      strategy = DeserializeStrategy::make<DeserializeProxy<Deserializer>>(); break;
+    }
+    case pds::Serialization::kRootUnrolled: {
+      strategy = DeserializeStrategy::make<DeserializeProxy<UnrolledDeserializer>>(); break;
+    }
+    }
+    laneInfos_.emplace_back(productInfo, std::move(strategy));
+  }
+
+
+}
+
+SharedRootEventSource::LaneInfo::LaneInfo(std::vector<pds::ProductInfo> const& productInfo, DeserializeStrategy deserialize):
+  deserializers_{std::move(deserialize)},
+  decompressTime_{std::chrono::microseconds::zero()},
+  deserializeTime_{std::chrono::microseconds::zero()}
+{
+  dataProducts_.reserve(productInfo.size());
+  dataBuffers_.resize(productInfo.size(), nullptr);
+  deserializers_.reserve(productInfo.size());
+  size_t index =0;
+  for(auto const& pi : productInfo) {
+    
+    TClass* cls = TClass::GetClass(pi.className().c_str());
+    dataBuffers_[index] = cls->New();
+    assert(cls);
+    dataProducts_.emplace_back(index,
+			       &dataBuffers_[index],
+                               pi.name(),
+                               cls,
+			       &delayedRetriever_);
+    deserializers_.emplace_back(cls);
+    ++index;
+  }
+}
+
+SharedRootEventSource::LaneInfo::~LaneInfo() {
+  auto it = dataProducts_.begin();
+  for( void * b: dataBuffers_) {
+    it->classType()->Destructor(b);
+    ++it;
+  }
+}
+
+size_t SharedRootEventSource::numberOfDataProducts() const {
+  return laneInfos_[0].dataProducts_.size();
+}
+
+std::vector<DataProductRetriever>& SharedRootEventSource::dataProducts(unsigned int iLane, long iEventIndex) {
+  return laneInfos_[iLane].dataProducts_;
+}
+
+EventIdentifier SharedRootEventSource::eventIdentifier(unsigned int iLane, long iEventIndex) {
+  return laneInfos_[iLane].eventID_;
+}
+
+void SharedRootEventSource::readEventAsync(unsigned int iLane, long iEventIndex,  OptionalTaskHolder iTask) {
+  queue_.push(*iTask.group(), [iLane, optTask = std::move(iTask), this, iEventIndex]() mutable {
+      auto start = std::chrono::high_resolution_clock::now();
+      if(iEventIndex < eventsTree_->GetEntries()) {
+        std::vector<uint32_t> buffer;
+        auto pBuffer = &buffer;
+        eventsBranch_->SetAddress(&pBuffer);
+        idBranch_->SetAddress(&this->laneInfos_[iLane].eventID_);
+        eventsTree_->GetEntry(iEventIndex);
+        {
+          auto const& id = this->laneInfos_[iLane].eventID_;
+          //std::cout <<"ID "<<id.run<<" "<<id.lumi<<" "<<id.event<<std::endl;
+          //std::cout <<"buffer size "<<buffer.size()<<std::endl;
+          //for(auto b: buffer) {
+          //  std::cout <<"  "<<b<<std::endl;
+          //}
+        }
+
+        buffer.erase(buffer.begin());
+        auto group = optTask.group();
+        group->run([this, buffer=std::move(buffer), task = optTask.releaseToTaskHolder(), iLane]() {
+            auto& laneInfo = this->laneInfos_[iLane];
+
+            auto start = std::chrono::high_resolution_clock::now();
+            std::vector<uint32_t> uBuffer = pds::uncompressEventBuffer(this->compression_, buffer);
+            //std::cout <<"uncompressed buffer size "<<uBuffer.size() <<std::endl;
+            laneInfo.decompressTime_ += 
+              std::chrono::duration_cast<decltype(laneInfo.decompressTime_)>(std::chrono::high_resolution_clock::now() - start);
+            
+            start = std::chrono::high_resolution_clock::now();
+            //uBuffer.pop_back();
+            pds::deserializeDataProducts(uBuffer.begin(), uBuffer.end(), laneInfo.dataProducts_, laneInfo.deserializers_);
+            laneInfo.deserializeTime_ += 
+              std::chrono::duration_cast<decltype(laneInfo.deserializeTime_)>(std::chrono::high_resolution_clock::now() - start);
+          });
+      }
+      readTime_ +=std::chrono::duration_cast<decltype(readTime_)>(std::chrono::high_resolution_clock::now() - start);
+    });
+}
+
+void SharedRootEventSource::printSummary() const {
+  std::cout <<"\nSource:\n"
+    "   read time: "<<readTime().count()<<"us\n"
+    "   decompress time: "<<decompressTime().count()<<"us\n"
+    "   deserialize time: "<<deserializeTime().count()<<"us\n"<<std::endl;
+};
+
+std::chrono::microseconds SharedRootEventSource::readTime() const {
+  return readTime_;
+}
+
+std::chrono::microseconds SharedRootEventSource::decompressTime() const {
+  auto time = std::chrono::microseconds::zero();
+  for(auto const& l : laneInfos_) {
+    time += l.decompressTime_;
+  }
+  return time;
+}
+
+std::chrono::microseconds SharedRootEventSource::deserializeTime() const {
+  auto time = std::chrono::microseconds::zero();
+  for(auto const& l : laneInfos_) {
+    time += l.deserializeTime_;
+  }
+  return time;
+}
+
+
+namespace {
+    class Maker : public SourceMakerBase {
+  public:
+    Maker(): SourceMakerBase("SharedRootEventSource") {}
+      std::unique_ptr<SharedSourceBase> create(unsigned int iNLanes, unsigned long long iNEvents, ConfigurationParameters const& params) const final {
+        auto fileName = params.get<std::string>("fileName");
+        if(not fileName) {
+          std::cout <<"no file name given\n";
+          return {};
+        }
+        return std::make_unique<SharedRootEventSource>(iNLanes, iNEvents, *fileName);
+    }
+    };
+
+  Maker s_maker;
+}

--- a/SharedRootEventSource.h
+++ b/SharedRootEventSource.h
@@ -1,0 +1,77 @@
+#if !defined(SharedRootEventSource_h)
+#define SharedRootEventSource_h
+
+#include <string>
+#include <memory>
+#include <chrono>
+#include <iostream>
+
+#include "TFile.h"
+#include "TTree.h"
+#include "TBranch.h"
+
+#include "SharedSourceBase.h"
+#include "DataProductRetriever.h"
+#include "DelayedProductRetriever.h"
+#include "SerialTaskQueue.h"
+#include "DeserializeStrategy.h"
+#include "pds_reading.h"
+
+
+namespace cce::tf {
+  class SharedRootEventDelayedRetriever : public DelayedProductRetriever {
+    void getAsync(DataProductRetriever&, int index, TaskHolder) final {}
+  };
+  
+  class SharedRootEventSource : public SharedSourceBase {
+  public:
+    SharedRootEventSource(unsigned int iNLanes, unsigned long long iNEvents, std::string const& iFileName);
+    SharedRootEventSource(SharedRootEventSource&&) = delete;
+    SharedRootEventSource(SharedRootEventSource const&) = delete;
+    ~SharedRootEventSource() = default;
+
+  size_t numberOfDataProducts() const final;
+  std::vector<DataProductRetriever>& dataProducts(unsigned int iLane, long iEventIndex) final;
+  EventIdentifier eventIdentifier(unsigned int iLane, long iEventIndex) final;
+
+  void printSummary() const final;
+  private:
+  
+  void readEventAsync(unsigned int iLane, long iEventIndex,  OptionalTaskHolder) final;
+
+  std::chrono::microseconds readTime() const;
+  std::chrono::microseconds decompressTime() const;
+  std::chrono::microseconds deserializeTime() const;
+
+  pds::Compression compression_;
+  std::unique_ptr<TFile> file_;
+  TTree* eventsTree_;
+  TBranch* eventsBranch_;
+  TBranch* idBranch_;
+  SerialTaskQueue queue_;
+
+  struct LaneInfo {
+    LaneInfo(std::vector<pds::ProductInfo> const&, DeserializeStrategy);
+
+    LaneInfo(LaneInfo&&) = default;
+    LaneInfo(LaneInfo const&) = delete;
+
+    LaneInfo& operator=(LaneInfo&&) = default;
+    LaneInfo& operator=(LaneInfo const&) = delete;
+
+    EventIdentifier eventID_;
+    std::vector<DataProductRetriever> dataProducts_;
+    std::vector<void*> dataBuffers_;
+    DeserializeStrategy deserializers_; //NOTE: could be shared between lanes?
+    SharedRootEventDelayedRetriever delayedRetriever_;
+    std::chrono::microseconds decompressTime_;
+    std::chrono::microseconds deserializeTime_;
+    ~LaneInfo();
+  };
+
+  std::vector<LaneInfo> laneInfos_;
+  std::chrono::microseconds readTime_;
+  };
+}
+
+#endif

--- a/pds_reading.cc
+++ b/pds_reading.cc
@@ -205,7 +205,7 @@ std::vector<uint32_t> pds::uncompressEventBuffer(pds::Compression compression, s
     ZSTD_decompress(uBuffer.data(), uncompressedBufferSize*4, &(*(buffer.begin()+1)), compressedBufferSizeInBytes);
   } else if(Compression::kNone == compression) {
     assert(buffer.size() == uBuffer.size()+2);
-    std::copy(buffer.begin()+1, buffer.begin()+buffer.size()-2, uBuffer.begin());
+    std::copy(buffer.begin()+1, buffer.begin()+buffer.size()-1, uBuffer.begin());
   }
   return uBuffer;
 }
@@ -215,14 +215,16 @@ void pds::deserializeDataProducts(buffer_iterator it, buffer_iterator itEnd, std
   while(it < itEnd) {
     auto productIndex = *(it++);
     auto storedSize = *(it++);
+    //std::cout <<" deserialize "<<productIndex<<" "<<storedSize<<std::endl;
 
     //std::cout <<dataProducts[productIndex].name()<<" "<<dataProducts[productIndex].classType()->GetName()<<std::endl;
     //std::cout <<"storedSize "<<storedSize<<" "<<storedSize*4<<std::endl;
     auto readSize = deserializers[productIndex].deserialize(reinterpret_cast<char const*>(&*it), storedSize*4, *dataProducts[productIndex].address());
     dataProducts[productIndex].setSize(readSize);
-  //std::cout <<" size "<<bufferFile.Length()<<"\n";
+    //std::cout <<" readSize "<<readSize<<"\n";
 
     it = it+storedSize;
+    //std::cout <<itEnd - it<<std::endl;
   }
   assert(it==itEnd);
 }

--- a/pds_reading.cc
+++ b/pds_reading.cc
@@ -190,7 +190,7 @@ bool pds::readCompressedEventBuffer(std::istream&file, EventIdentifier& iEventID
 
 
 std::vector<uint32_t> pds::uncompressEventBuffer(pds::Compression compression, std::vector<uint32_t> const& buffer) {
-  int32_t bufferSize = buffer.size()-1; //The last word of the buffer is a crosscheck and not part of the data.
+  int32_t bufferSize = buffer.size();
   //lower 2 bits are the number of bytes used in the last word of the compressed sized
   int32_t uncompressedBufferSize = buffer[0]/4;
   int32_t bytesInLastWord = buffer[0] % 4;
@@ -205,7 +205,7 @@ std::vector<uint32_t> pds::uncompressEventBuffer(pds::Compression compression, s
     ZSTD_decompress(uBuffer.data(), uncompressedBufferSize*4, &(*(buffer.begin()+1)), compressedBufferSizeInBytes);
   } else if(Compression::kNone == compression) {
     assert(buffer.size() == uBuffer.size()+2);
-    std::copy(buffer.begin()+1, buffer.begin()+buffer.size()-1, uBuffer.begin());
+    std::copy(buffer.begin()+1, buffer.begin()+buffer.size(), uBuffer.begin());
   }
   return uBuffer;
 }


### PR DESCRIPTION
The *RootEvent* classes store all Event data products as a compressed blob into one TBranch of the Events TTree.