### PR TITLE
Added Separate 'offset' TBranch to RootEvent format

### DIFF
--- a/RootEventOutputer.cc
+++ b/RootEventOutputer.cc
@@ -26,6 +26,7 @@ RootEventOutputer::RootEventOutputer(std::string const& iFileName, unsigned int 
     //gDebug = 3;
     eventsTree_ = new TTree("Events", "", 0, &file_);
 
+    eventsTree_->Branch("offsets", &dataProductOffsets_);
     eventsTree_->Branch("blob", &eventBlob_);
     eventsTree_->Branch("EventID", &eventID_, "run/i:lumi/i:event/l");
 
@@ -53,6 +54,7 @@ void RootEventOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataPr
     {   s = SerializeStrategy::make<SerializeProxy<UnrolledSerializerWrapper>>(); break; }
   }
   s.reserve(iDPs.size());
+  dataProductOffsets_.resize(iDPs.size()+1,0);
   for(auto const& dp: iDPs) {
     s.emplace_back(dp.name(), dp.classType());
   }
@@ -66,11 +68,10 @@ void RootEventOutputer::productReadyAsync(unsigned int iLaneIndex, DataProductRe
 
 void RootEventOutputer::outputAsync(unsigned int iLaneIndex, EventIdentifier const& iEventID, TaskHolder iCallback) const {
   auto start = std::chrono::high_resolution_clock::now();
-  auto tempBuffer = std::make_unique<std::vector<uint32_t>>(writeDataProductsToOutputBuffer(serializers_[iLaneIndex]));
-  queue_.push(*iCallback.group(), [this, iEventID, iLaneIndex, callback=std::move(iCallback), buffer=std::move(tempBuffer)]() mutable {
+  auto [offsets, buffer] = writeDataProductsToOutputBuffer(serializers_[iLaneIndex]);
+  queue_.push(*iCallback.group(), [this, iEventID, iLaneIndex, callback=std::move(iCallback), buffer = std::move(buffer), offsets = std::move(offsets)]() mutable {
       auto start = std::chrono::high_resolution_clock::now();
-      const_cast<RootEventOutputer*>(this)->output(iEventID, serializers_[iLaneIndex],*buffer);
-      buffer.reset();
+      const_cast<RootEventOutputer*>(this)->output(iEventID, serializers_[iLaneIndex],std::move(buffer), std::move(offsets));
         serialTime_ += std::chrono::duration_cast<decltype(serialTime_)>(std::chrono::high_resolution_clock::now() - start);
       callback.doneWaiting();
     });
@@ -98,7 +99,7 @@ void RootEventOutputer::printSummary() const  {
 
 
 
-void RootEventOutputer::output(EventIdentifier const& iEventID, SerializeStrategy const& iSerializers, std::vector<uint32_t>const& iBuffer) {
+void RootEventOutputer::output(EventIdentifier const& iEventID, SerializeStrategy const& iSerializers, std::vector<char> iBuffer, std::vector<uint32_t> iOffsets) {
   if(firstTime_) {
     writeMetaData(iSerializers);
     firstTime_ = false;
@@ -107,9 +108,9 @@ void RootEventOutputer::output(EventIdentifier const& iEventID, SerializeStrateg
   
   //std::cout <<"   run:"s+std::to_string(iEventID.run)+" lumi:"s+std::to_string(iEventID.lumi)+" event:"s+std::to_string(iEventID.event)+"\n"<<std::flush;
   
-  //writeEventID(iEventID);
   eventID_ = iEventID;
   eventBlob_ = std::move(iBuffer);
+  dataProductOffsets_ = std::move(iOffsets);
   //std::cout <<"Event "<<eventID_.run<<" "<<eventID_.lumi<<" "<<eventID_.event<<std::endl;
   //std::cout <<"buffer size "<<eventBlob_.size();
   //for(auto b: eventBlob_) {
@@ -146,50 +147,40 @@ void RootEventOutputer::writeMetaData(SerializeStrategy const& iSerializers) {
 
 }
 
-std::vector<uint32_t> RootEventOutputer::writeDataProductsToOutputBuffer(SerializeStrategy const& iSerializers) const{
+std::pair<std::vector<uint32_t>, std::vector<char>> RootEventOutputer::writeDataProductsToOutputBuffer(SerializeStrategy const& iSerializers) const{
   //Calculate buffer size needed
   uint32_t bufferSize = 0;
+  std::vector<uint32_t> offsets;
+  offsets.reserve(iSerializers.size()+1);
   for(auto const& s: iSerializers) {
-    bufferSize +=1+1;
     auto const blobSize = s.blob().size();
-    bufferSize += bytesToWords(blobSize); //handles padding
+    offsets.push_back(bufferSize);
+    bufferSize += blobSize;
   }
+  offsets.push_back(bufferSize);
+
   //initialize with 0
-  std::vector<uint32_t> buffer(size_t(bufferSize), 0);
+  std::vector<char> buffer(bufferSize, 0);
   
   {
-    uint32_t bufferIndex = 0;
-    uint32_t dataProductIndex = 0;
+    uint32_t index = 0;
     for(auto const& s: iSerializers) {
       //std::cout <<"  write: "<<s.name()<<std::endl;
-      buffer[bufferIndex++]=dataProductIndex++;
-      auto const blobSize = s.blob().size();
-      uint32_t sizeInWords = bytesToWords(blobSize);
-      buffer[bufferIndex++]=sizeInWords;
-      std::copy(s.blob().begin(), s.blob().end(), reinterpret_cast<char*>( &(*(buffer.begin()+bufferIndex)) ) );
-      bufferIndex += sizeInWords;
+      auto offset = offsets[index++];
+      std::copy(s.blob().begin(), s.blob().end(), buffer.begin()+offset );
     }
-    assert(buffer.size() == bufferIndex);
+    assert(buffer.size() == offset[index]);
   }
 
-  //will prepend one extra space at the beginning
-  auto [cBuffer, cSize] = compressBuffer(buffer);
+  auto cBuffer  = compressBuffer(buffer);
 
-  //std::cout <<"compressed "<<cSize<<" uncompressed "<<buffer.size()*4<<std::endl;
-  //std::cout <<"compressed "<<(buffer.size()*4)/float(cSize)<<std::endl;
-  uint32_t const recordSize = bytesToWords(cSize)+1;
-  //Record the actual number of bytes used in the last word of the compression buffer in the lowest
-  // 2 bits of the word
-  cBuffer[0] = buffer.size()*4 + (cSize % 4);
-  if(cBuffer.size() != recordSize+1) {
-    std::cout <<"BAD BUFFER SIZE: want: "<<recordSize+1<<" got "<<cBuffer.size()<<std::endl;
-  }
-  assert(cBuffer.size() == recordSize+1);
-  return cBuffer;
+  //std::cout <<"compressed "<<cSize<<" uncompressed "<<buffer.size()<<std::endl;
+  //std::cout <<"compressed "<<(buffer.size())/float(cSize)<<std::endl;
+  return {offsets,cBuffer};
 }
 
-std::pair<std::vector<uint32_t>, int> RootEventOutputer::compressBuffer(std::vector<uint32_t> const& iBuffer) const {
-  return pds::compressBuffer(1, 0, compression_, compressionLevel_, iBuffer);
+std::vector<char> RootEventOutputer::compressBuffer(std::vector<char> const& iBuffer) const {
+  return pds::compressBuffer(0, 0, compression_, compressionLevel_, iBuffer);
 }
 
 namespace {

--- a/RootEventOutputer.h
+++ b/RootEventOutputer.h
@@ -33,16 +33,12 @@ class RootEventOutputer :public OutputerBase {
   void printSummary() const final;
 
  private:
-  static inline size_t bytesToWords(size_t nBytes) {
-    return nBytes/4 + ( (nBytes % 4) == 0 ? 0 : 1);
-  }
-
-  void output(EventIdentifier const& iEventID, SerializeStrategy const& iSerializers, std::vector<uint32_t> const& iBuffer);
+  void output(EventIdentifier const& iEventID, SerializeStrategy const& iSerializers, std::vector<char>  iBuffer, std::vector<uint32_t> iOffset);
   void writeMetaData(SerializeStrategy const& iSerializers);
 
-  std::vector<uint32_t> writeDataProductsToOutputBuffer(SerializeStrategy const& iSerializers) const;
+  std::pair<std::vector<uint32_t>,std::vector<char>> writeDataProductsToOutputBuffer(SerializeStrategy const& iSerializers) const;
 
-  std::pair<std::vector<uint32_t>, int> compressBuffer(std::vector<uint32_t> const& iBuffer) const;
+  std::vector<char> compressBuffer(std::vector<char> const& iBuffer) const;
 
 private:
   mutable TFile file_;
@@ -51,7 +47,8 @@ private:
 
   mutable SerialTaskQueue queue_;
   mutable std::vector<SerializeStrategy> serializers_;
-  mutable std::vector<uint32_t> eventBlob_;
+  mutable std::vector<uint32_t> dataProductOffsets_;
+  mutable std::vector<char> eventBlob_;
   EventIdentifier eventID_;
   pds::Compression compression_;
   int compressionLevel_;

--- a/SharedRootEventSource.h
+++ b/SharedRootEventSource.h
@@ -47,6 +47,7 @@ namespace cce::tf {
   std::unique_ptr<TFile> file_;
   TTree* eventsTree_;
   TBranch* eventsBranch_;
+  TBranch* offsetsBranch_;
   TBranch* idBranch_;
   SerialTaskQueue queue_;
 

--- a/pds_reading.h
+++ b/pds_reading.h
@@ -38,6 +38,11 @@ namespace cce::tf::pds {
   std::vector<uint32_t> uncompressEventBuffer(pds::Compression, std::vector<uint32_t> const& buffer);
   void deserializeDataProducts(std::vector<uint32_t>::const_iterator, std::vector<uint32_t>::const_iterator, std::vector<DataProductRetriever>&, DeserializeStrategy const&);
 
+  std::vector<char> uncompressBuffer(pds::Compression, std::vector<char> const& buffer, uint32_t uncompressedSize);
+  void deserializeDataProducts(const char* iBufferBegin, const char* iBufferEnd, 
+                               std::vector<uint32_t>::const_iterator itTableBegin, std::vector<uint32_t>::const_iterator itTableEnd, 
+                               std::vector<DataProductRetriever>&, DeserializeStrategy const&);
+
 }
 
 #endif

--- a/pds_writer.cc
+++ b/pds_writer.cc
@@ -39,6 +39,34 @@ namespace {
     cBuffer.resize(bytesToWords(cSize)+iLeadPadding+iTrailingPadding);
     return {cBuffer,cSize};
   }
+
+
+  std::vector<char> lz4CompressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<char> const& iBuffer) {
+    auto const bound = LZ4_compressBound(iBuffer.size());
+    std::vector<char> cBuffer(bound+iLeadPadding+iTrailingPadding, 0);
+    auto cSize = LZ4_compress_default(&(*iBuffer.begin()), &(*(cBuffer.begin()+iLeadPadding)), iBuffer.size(), bound);
+    cBuffer.resize(cSize+iLeadPadding+iTrailingPadding);
+    return cBuffer;
+  }
+  
+  std::vector<char> noCompressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<char> const& iBuffer) {
+    std::vector<char> cBuffer(iBuffer.size()+iLeadPadding+iTrailingPadding, uint32_t(0));
+    std::copy(iBuffer.begin(), iBuffer.end(), cBuffer.begin()+iLeadPadding);
+    return cBuffer;
+  }
+  
+  std::vector<char> zstdCompressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, std::vector<char> const& iBuffer, int compressionLevel) {
+    int cSize = 0;
+    auto const bound = ZSTD_compressBound(iBuffer.size());
+    std::vector<char> cBuffer(bound+iLeadPadding+iTrailingPadding, 0);
+    cSize = ZSTD_compress(&(*(cBuffer.begin()+iLeadPadding)), bound, &(*iBuffer.begin()),  iBuffer.size(), compressionLevel);
+    if(ZSTD_isError(cSize)) {
+      std::cout <<"ERROR in comparession "<<ZSTD_getErrorName(cSize)<<std::endl;
+    }
+    cBuffer.resize(cSize+iLeadPadding+iTrailingPadding);
+    return cBuffer;
+  }
+
 }
 
 namespace cce::tf::pds {
@@ -60,4 +88,23 @@ namespace cce::tf::pds {
       
     }
   }
+
+  std::vector<char> compressBuffer(unsigned int iLeadPadding, unsigned int iTrailingPadding, Compression iAlgorithm, int iCompressionLevel, std::vector<char> const& iBuffer) {
+
+    switch(iAlgorithm) {
+    case Compression::kLZ4 : {
+      return lz4CompressBuffer(iLeadPadding,iTrailingPadding, iBuffer);
+    }    
+    case Compression::kNone : {
+      return noCompressBuffer(iLeadPadding, iTrailingPadding, iBuffer);
+    } 
+    case Compression::kZSTD : {
+      return zstdCompressBuffer(iLeadPadding, iTrailingPadding, iBuffer, iCompressionLevel);
+    }
+    default:
+      return noCompressBuffer(iLeadPadding, iTrailingPadding, iBuffer);
+      
+    }
+  }
+
 }

--- a/pds_writer.h
+++ b/pds_writer.h
@@ -10,6 +10,9 @@
 namespace cce::tf::pds {
 
   std::pair<std::vector<uint32_t>, int> compressBuffer(unsigned int iReserveFirstNWords, unsigned int iPadding, Compression iAlgorithm, int iCompressionLevel, std::vector<uint32_t> const& iBuffer);
+
+  std::vector<char> compressBuffer(unsigned int iReserveFirstNWords, unsigned int iPadding, Compression iAlgorithm, int iCompressionLevel, std::vector<char> const& iBuffer);
+
 }
 
 #endif


### PR DESCRIPTION
By splitting the offset away from the buffer, ROOT can properly store/retrieve the correct type for both the offset and the buffers.