### PR TITLE
Copy lane reference count into lambda

### DIFF
--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -162,7 +162,7 @@ int main(int argc, char* argv[]) {
       AtomicRefCounter laneCounter(nLanesWaiting);
       for(auto& lane: lanes) {
         auto& group = *itGroup;
-        group.run([&]() {lane.processEventsAsync(ievt,group, *pOut,laneCounter);});
+        group.run([&, laneCounter]() {lane.processEventsAsync(ievt,group, *pOut,laneCounter);});
         ++itGroup;
       }
     }


### PR DESCRIPTION
This avoids a failure with SerialRootSource where jobs would prematurely end as the reference count would be incremented too late.