### PR TITLE
Allow alternative Waiters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ add_executable(threaded_io_test
   ConfigurationParameters.cc
   OutputerFactory.cc
   outputerFactoryGenerator.cc
+  WaiterFactory.cc
+  waiterFactoryGenerator.cc
+  ScaleWaiter.cc
   pds_reading.cc
   pds_writer.cc
   pds_common.cc
@@ -153,6 +156,7 @@ add_test(NAME TBufferMergerRootOutputerEmptyTest COMMAND threaded_io_test -s Emp
 add_test(NAME TBufferMergerRootOutputerEmptySplitLevelTest COMMAND threaded_io_test -s EmptySource -t 1 -n 10 -o TBufferMergerRootOutputer=test_empty.root:splitLevel=1)
 add_test(NAME TBufferMergerRootOutputerEmptyAllOptionsTest COMMAND threaded_io_test -s EmptySource -t 1 -n 10 -o TBufferMergerRootOutputer=test_empty.root:splitLevel=1:compressionLevel=1:compressionAlgorithm=LZMA:basketSize=32000:treeMaxVirtualSize=-1:autoFlush=900)
 add_test(NAME UseIMTTest COMMAND threaded_io_test -s EmptySource -t 1 --use-IMT=t -n 10)
+add_test(NAME ScaleWaiterTest COMMAND threaded_io_test -s TestProductsSource -t 1 -n 10 -w ScaleWaiter=scale=1000.)
 
 option(ENABLE_HDF5 "Build HDF5 Sources and Outputers" ON) # default ON
 if(ENABLE_HDF5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(threaded_io_test
   WaiterFactory.cc
   waiterFactoryGenerator.cc
   ScaleWaiter.cc
+  EventSleepWaiter.cc
   pds_reading.cc
   pds_writer.cc
   pds_common.cc
@@ -157,6 +158,7 @@ add_test(NAME TBufferMergerRootOutputerEmptySplitLevelTest COMMAND threaded_io_t
 add_test(NAME TBufferMergerRootOutputerEmptyAllOptionsTest COMMAND threaded_io_test -s EmptySource -t 1 -n 10 -o TBufferMergerRootOutputer=test_empty.root:splitLevel=1:compressionLevel=1:compressionAlgorithm=LZMA:basketSize=32000:treeMaxVirtualSize=-1:autoFlush=900)
 add_test(NAME UseIMTTest COMMAND threaded_io_test -s EmptySource -t 1 --use-IMT=t -n 10)
 add_test(NAME ScaleWaiterTest COMMAND threaded_io_test -s TestProductsSource -t 1 -n 10 -w ScaleWaiter=scale=1000.)
+add_test(NAME EventSleepWaiterTest COMMAND bash -c "echo 300000 > times.wait; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s TestProductsSource -t 1 -n 10 -w EventSleepWaiter=filename=times.wait")
 
 option(ENABLE_HDF5 "Build HDF5 Sources and Outputers" ON) # default ON
 if(ENABLE_HDF5)

--- a/ConfigurationParameters.cc
+++ b/ConfigurationParameters.cc
@@ -17,6 +17,11 @@ namespace cce::tf {
   }
 
   template<>
+    float ConfigurationParameters::convert<float>(std::string const& iValue) {
+    return std::stof(iValue);
+  }
+
+  template<>
   bool ConfigurationParameters::convert<bool>(std::string const& iValue) {
     return (iValue.empty()) or (
                                      (iValue[0] == 't') or (iValue[0] == 'T') or (iValue[0] == 'y') or (iValue[0] == 'Y')

--- a/ConfigurationParameters.h
+++ b/ConfigurationParameters.h
@@ -74,6 +74,9 @@ namespace cce::tf {
   template<>
     bool ConfigurationParameters::convert<bool>(std::string const& iValue);
 
+  template<>
+    float ConfigurationParameters::convert<float>(std::string const& iValue);
+
 
 }
 

--- a/EventSleepWaiter.cc
+++ b/EventSleepWaiter.cc
@@ -1,0 +1,76 @@
+
+#include <vector>
+#include <fstream>
+#include <thread>
+#include <iostream>
+#include "EventIdentifier.h"
+#include "DataProductRetriever.h"
+#include "TaskHolder.h"
+#include "WaiterBase.h"
+#include "WaiterFactory.h"
+
+
+namespace cce::tf {
+  class EventSleepWaiter : public WaiterBase {
+ public:
+
+    EventSleepWaiter(std::vector<double> iEventSleepTimes, std::size_t iNDataProducts):
+      sleepTimes_(std::move(iEventSleepTimes)),
+      nDataProducts_{iNDataProducts} {}
+
+    void waitAsync(unsigned int iLaneIndex, EventIdentifier const& iEventID, long iEventIndex,
+                   std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, 
+                   TaskHolder iCallback) const final {
+      iCallback.group()->run([iCallback, iEventIndex, this]() {
+	  using namespace std::chrono_literals;
+          auto index = iEventIndex % sleepTimes_.size();
+	  auto sleep = (sleepTimes_[index]/nDataProducts_)*1us;
+	  //std::cout <<"sleep "<<sleep.count()<<std::endl;
+	  std::this_thread::sleep_for( sleep);
+	  //std::cout <<"awake"<<std::endl;
+	});
+    }
+
+ private:
+    std::vector<double> sleepTimes_;
+    std::size_t nDataProducts_;
+};
+}
+
+namespace {
+
+  using namespace cce::tf;
+  class Maker : public WaiterMakerBase {
+  public:
+    Maker(): WaiterMakerBase("EventSleepWaiter") {}
+
+    std::unique_ptr<WaiterBase> create(unsigned int iNLanes, std::size_t iNDataProducts, ConfigurationParameters const& params) const final {
+
+      auto filename = params.get<std::string>("filename");
+      if(not filename) {
+        std::cout <<"no file name give for EventSleepWaiter"<<std::endl;
+        return {};
+      }
+
+      std::ifstream file(*filename);
+      if(not file.is_open()) {
+        std::cout <<"unable to open file "<<*filename<<" with sleep times";
+        return {};
+      }
+      double value;
+      std::vector<double> sleepTimes;
+      while(file >> value) {
+        sleepTimes.push_back(value);
+      }
+      if(sleepTimes.empty()) {
+        std::cout <<"file "<<*filename<<" contained no event times"<<std::endl;
+        return {};
+      }
+
+      return std::make_unique<EventSleepWaiter>(std::move(sleepTimes), iNDataProducts);
+    }
+    
+  };
+
+  Maker s_maker;
+}

--- a/Lane.cc
+++ b/Lane.cc
@@ -22,7 +22,10 @@ TaskHolder Lane::makeWaiterTask(tbb::task_group& group, size_t index, TaskHolder
   } else {  
     return TaskHolder(group,
                       make_functor_task([index,  holder, this]() {
-                          waiter_->waitAsync(dataProducts(),index, std::move(holder));
+                          waiter_->waitAsync(index_, 
+                                             source_->eventIdentifier(index_, presentEventIndex_),
+                                             presentEventIndex_,
+                                             dataProducts(),index, std::move(holder));
                         }) );
   }
 }

--- a/Lane.cc
+++ b/Lane.cc
@@ -7,13 +7,7 @@
 
 using namespace cce::tf;
 
-Lane::Lane(unsigned int iIndex, SharedSourceBase* iSource, double iScaleFactor): source_(iSource), index_{iIndex} {
-    if(iScaleFactor >=0.) {
-      waiters_.reserve(source_->numberOfDataProducts());
-      for( int ib = 0; ib< source_->numberOfDataProducts(); ++ib) {
-	waiters_.emplace_back(ib, iScaleFactor);
-      }
-    }
+Lane::Lane(unsigned int iIndex, SharedSourceBase* iSource, Waiter const* iWaiter): source_(iSource), waiter_(iWaiter), index_{iIndex} {
 }
 
 void Lane::processEventsAsync(std::atomic<long>& index, tbb::task_group& group, const OutputerBase& outputer, 
@@ -23,14 +17,12 @@ void Lane::processEventsAsync(std::atomic<long>& index, tbb::task_group& group, 
 
 
 TaskHolder Lane::makeWaiterTask(tbb::task_group& group, size_t index, TaskHolder holder) {
-  if(waiters_.empty()) {
+  if(not waiter_) {
     return holder;
   } else {  
     return TaskHolder(group,
                       make_functor_task([index,  holder, this]() {
-                          auto laneIndex = this->index_;
-                          auto& w = waiters_[index];
-                          w.waitAsync(dataProducts(),std::move(holder));
+                          waiter_->waitAsync(dataProducts(),index, std::move(holder));
                         }) );
   }
 }

--- a/Lane.cc
+++ b/Lane.cc
@@ -7,7 +7,7 @@
 
 using namespace cce::tf;
 
-Lane::Lane(unsigned int iIndex, SharedSourceBase* iSource, Waiter const* iWaiter): source_(iSource), waiter_(iWaiter), index_{iIndex} {
+Lane::Lane(unsigned int iIndex, SharedSourceBase* iSource, WaiterBase const* iWaiter): source_(iSource), waiter_(iWaiter), index_{iIndex} {
 }
 
 void Lane::processEventsAsync(std::atomic<long>& index, tbb::task_group& group, const OutputerBase& outputer, 

--- a/Lane.h
+++ b/Lane.h
@@ -15,7 +15,7 @@
 namespace cce::tf {
 class Lane {
 public:
-  Lane(unsigned int iIndex, SharedSourceBase* iSource, double iScaleFactor);
+  Lane(unsigned int iIndex, SharedSourceBase* iSource, Waiter const* iWaiter);
 
   void processEventsAsync(std::atomic<long>& index, tbb::task_group& group, const OutputerBase& outputer, AtomicRefCounter);
 
@@ -37,7 +37,7 @@ private:
 		   AtomicRefCounter counter);
 
   SharedSourceBase* source_;
-  std::vector<Waiter> waiters_;
+  Waiter const* waiter_;
   long presentEventIndex_ = -1;
   unsigned int index_;
   bool verbose_ = false;

--- a/Lane.h
+++ b/Lane.h
@@ -9,13 +9,13 @@
 
 #include "SharedSourceBase.h"
 #include "OutputerBase.h"
-#include "Waiter.h"
+#include "WaiterBase.h"
 #include "AtomicRefCounter.h"
 
 namespace cce::tf {
 class Lane {
 public:
-  Lane(unsigned int iIndex, SharedSourceBase* iSource, Waiter const* iWaiter);
+  Lane(unsigned int iIndex, SharedSourceBase* iSource, WaiterBase const* iWaiter);
 
   void processEventsAsync(std::atomic<long>& index, tbb::task_group& group, const OutputerBase& outputer, AtomicRefCounter);
 
@@ -37,7 +37,7 @@ private:
 		   AtomicRefCounter counter);
 
   SharedSourceBase* source_;
-  Waiter const* waiter_;
+  WaiterBase const* waiter_;
   long presentEventIndex_ = -1;
   unsigned int index_;
   bool verbose_ = false;

--- a/README.md
+++ b/README.md
@@ -43,26 +43,22 @@ infer the build information for TBB, zstd, and lz4.  If the ROOT
 runtime is setup, one can use `-DROOT_DIR=$ROOTSYS/cmake`.
 
 ## threaded_io_test design
-The testing structure has 2 customizable component types
+The testing structure has 3 customizable component types
 1. `Source`s: These supply the _event_ data products used for testing.
 1. `Outputer`s: These read the _event_ data products. Some Outputers also write that data out for storage.
+1. `Waiter`s: These get called for each _event_ data product after the data products are read from testing. The `Outputer` is called
+once the `Waiter` has finished its asynchronous callback for the data product. This allows tuning the timing of events to better mimic actual HEP data processing.
 
-In order to mimic the time taken to process event data, the testing structure has `Waiter`s. A `Waiter` read one _event_ data product and based on a property of that data
-product calls sleep for a length proportional to that property.
+The testing structure can process multiple _events_ concurrently. The processing of 
+an _event_ is handled by a `Lane`. Concurrent _events_ are then done by having multiple `Lane`s.
 
-The testing structure can process multiple _events_ concurrently. Each concurrent _event_ has its own set of `Waiter`s, one for each data product. The processing of 
-an _event_ is handled by a `Lane`. Concurrent _events_ are then done by having multiple `Lane`s. The `Waiter`s within a `Lane` are considered to be completely 
-independent and can be run concurrently.
-
-All `Lane`s share the same `Outputer`. Therefore an `Outputer` is required to be thread safe.
-
-All `Lane`s share the same `Source`. Therefore a `Source` is required to be thread safe.
+All `Lane`s share the same `Source`, `Waiter`, and `Outputer`. Therefore all three of these types are required to be thread safe.
 
 The way data is processed is as follows:
 1. When a `Lane` is no longer processing an _event_ it requests a new one from the system. The system advances an atomic counter and tells the `Lane` to use the _event_ associated with that index.
 1. The `Lane` then passes the _event_ index to the `Source` and asks it to asynchronously retrieve the _event_ data products.
 1. Once the `Source` has retrieved the data products, it signals to the `Waiter`s to run asynchronously.
-1. Once each `Waiter` has finished, the system signals to the `Outputer` that the particular _event_ data product is available for the `Outputer`. The `Outputer`
+1. Once the`Waiter` has finished with each data product, the system signals to the `Outputer` that the particular _event_ data product is available for the `Outputer`. The `Outputer`
 can then asynchronously process that data product.
 1. Once the `Outputer` has finished with all the data products, the system signals the `Outputer` that the _event_ has finished. The `Outputer` can then do
 additional asynchronous work.
@@ -71,14 +67,14 @@ additional asynchronous work.
 ## Running tests
 The `threaded_io_test` takes the following command line arguments
 ```
-threaded_io_test -s <Source configuration> [-t <# threads>] [--use-IMT=<T/F>] [-l <# conconcurrent events>] [-s <time scale factor>] [ -n <max # events>] [-o <Outputer configuration>]
+threaded_io_test -s <Source configuration> [-t <# threads>] [--use-IMT=<T/F>] [-l <# conconcurrent events>] [-w <Waiter configuration>] [ -n <max # events>] [-o <Outputer configuration>]
 ```
 
 1. `--source, -s` `<Source configuration>` : which `Source` to use and any additional information needed to configure it. Options are described below.
 1. `--num-threads, -t` `<# threads>` : number of threads to use in the job. 
 1. `--use-IMT` turn on or off ROOT's implicit multithreaded (IMT). Default is off.
 1. `--num-lanes, -l` `<# concurrent events>` : number of concurrent _events_ (that is `Lane`s) to use. Best if number of events is less than  or equal to number of threads. Default is the value used for `--num-threads`.
-1. `--scale` `<time scale factor>` : used to convert the property of the _event_ data products into microseconds used for the sleep call. A value of 0 means no sleeping. A value less than 0 prohibits the creation of the objects which do the sleep. Default is -1.
+1. `--waiter, -w` `<Waiter configuration>` : used to specify which `Waiter` to use and any additional information needed to configure it. The exact options are described below. Default is '' which causes no `Waiter` to be used.
 1. `--num-events, -n` `<max # events>` : max number of events to process in the job. Default is largest possible 64 bit value.
 1. `--outputer, -o`  `<Outputer configuration>` : used to specify which `Outputer` to use and any additional information needed to configure it. The exact options are described below. Default is `DummyOutputer`.
 
@@ -288,6 +284,12 @@ or
 ```
 > threaded_io_test -s ReplicatedRootSource=test.root -t 1 -n 10 -o RootBatchEventsOutputer=test.root:batchSize=4
 ```
+
+### Waiters
+
+#### ScaleWaiter
+For each data product this waiter sleeps for an amount of time proportional to the `size` property of the data product. The configuration options are:
+- scale: used to convert the size property of the _event_ data products into microseconds used for a call to sleep. A value of 0 means no sleeping.
 
 
 ## unroll_test

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ or
 For each data product this waiter sleeps for an amount of time proportional to the `size` property of the data product. The configuration options are:
 - scale: used to convert the size property of the _event_ data products into microseconds used for a call to sleep. A value of 0 means no sleeping.
 
+#### EventSleepWaiter
+This waiter reads a file containing the total time it should sleep for each event. If the number of events in the file is less than the total number of the job, the waiter will repeat the same sleep times. The order of the sleep times is guaranteed to line up with the order of Events coming from the Source. The waiter divides the event sleep time equally among all the data products.
+The configuration options are:
+- filename: the name of the file containing the event sleep times. The event entries must be separated by white space. The sleep times are in microseconds. 
 
 ## unroll_test
 

--- a/ScaleWaiter.cc
+++ b/ScaleWaiter.cc
@@ -12,10 +12,12 @@ namespace cce::tf {
   class ScaleWaiter : public WaiterBase {
  public:
 
- ScaleWaiter(std::size_t iNumberOfDataProducts,  double iScaleFactor):
+ ScaleWaiter(double iScaleFactor):
   scale_{iScaleFactor} {}
 
-    void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, TaskHolder iCallback) const final {
+    void waitAsync(unsigned int iLaneIndex, EventIdentifier const& iEventID, long iEventIndex,
+                   std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, 
+                   TaskHolder iCallback) const final {
       iCallback.group()->run([iCallback, &iRetrievers, scale=scale_, index]() {
 	  using namespace std::chrono_literals;
 	  auto sleep = scale*iRetrievers[index].size()*1us;
@@ -37,11 +39,11 @@ namespace {
   public:
     Maker(): WaiterMakerBase("ScaleWaiter") {}
 
-    std::unique_ptr<WaiterBase> create(std::size_t iNDataProducts, ConfigurationParameters const& params) const final {
+    std::unique_ptr<WaiterBase> create(unsigned int iNLanes, std::size_t iNDataProducts, ConfigurationParameters const& params) const final {
 
       auto scale = params.get<float>("scale", 0);
 
-      return std::make_unique<ScaleWaiter>(iNDataProducts, scale);
+      return std::make_unique<ScaleWaiter>(scale);
     }
     
   };

--- a/ScaleWaiter.cc
+++ b/ScaleWaiter.cc
@@ -1,5 +1,3 @@
-#if !defined(Waiter_h)
-#define Waiter_h
 
 #include <vector>
 #include <thread>
@@ -7,12 +5,14 @@
 #include "DataProductRetriever.h"
 #include "TaskHolder.h"
 #include "WaiterBase.h"
+#include "WaiterFactory.h"
+
 
 namespace cce::tf {
-  class Waiter : public WaiterBase {
+  class ScaleWaiter : public WaiterBase {
  public:
 
- Waiter(std::size_t iNumberOfDataProducts,  double iScaleFactor):
+ ScaleWaiter(std::size_t iNumberOfDataProducts,  double iScaleFactor):
   scale_{iScaleFactor} {}
 
     void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, TaskHolder iCallback) const final {
@@ -29,4 +29,22 @@ namespace cce::tf {
   double scale_;
 };
 }
-#endif
+
+namespace {
+
+  using namespace cce::tf;
+  class Maker : public WaiterMakerBase {
+  public:
+    Maker(): WaiterMakerBase("ScaleWaiter") {}
+
+    std::unique_ptr<WaiterBase> create(std::size_t iNDataProducts, ConfigurationParameters const& params) const final {
+
+      auto scale = params.get<float>("scale", 0);
+
+      return std::make_unique<ScaleWaiter>(iNDataProducts, scale);
+    }
+    
+  };
+
+  Maker s_maker;
+}

--- a/Waiter.h
+++ b/Waiter.h
@@ -6,15 +6,16 @@
 #include "EventIdentifier.h"
 #include "DataProductRetriever.h"
 #include "TaskHolder.h"
+#include "WaiterBase.h"
 
 namespace cce::tf {
-class Waiter {
+  class Waiter : public WaiterBase {
  public:
 
  Waiter(std::size_t iNumberOfDataProducts,  double iScaleFactor):
   scale_{iScaleFactor} {}
 
-    void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, TaskHolder iCallback) const {
+    void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, TaskHolder iCallback) const final {
       iCallback.group()->run([iCallback, &iRetrievers, scale=scale_, index]() {
 	  using namespace std::chrono_literals;
 	  auto sleep = scale*iRetrievers[index].size()*1us;

--- a/Waiter.h
+++ b/Waiter.h
@@ -11,12 +11,11 @@ namespace cce::tf {
 class Waiter {
  public:
 
- Waiter(unsigned int iDataProductIndex, double iScaleFactor):
-  scale_{iScaleFactor},
-    index_{iDataProductIndex} {}
+ Waiter(std::size_t iNumberOfDataProducts,  double iScaleFactor):
+  scale_{iScaleFactor} {}
 
-    void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, TaskHolder iCallback) const {
-      iCallback.group()->run([iCallback, &iRetrievers, scale=scale_, index= index_]() {
+    void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, TaskHolder iCallback) const {
+      iCallback.group()->run([iCallback, &iRetrievers, scale=scale_, index]() {
 	  using namespace std::chrono_literals;
 	  auto sleep = scale*iRetrievers[index].size()*1us;
 	  //std::cout <<"sleep "<<sleep.count()<<std::endl;
@@ -27,7 +26,6 @@ class Waiter {
 
  private:
   double scale_;
-  unsigned int index_;
 };
 }
 #endif

--- a/WaiterBase.h
+++ b/WaiterBase.h
@@ -1,0 +1,20 @@
+#if !defined(WaiterBase_h)
+#define WaiterBase_h
+
+#include <vector>
+#include <thread>
+#include "EventIdentifier.h"
+#include "DataProductRetriever.h"
+#include "TaskHolder.h"
+
+namespace cce::tf {
+class WaiterBase {
+ public:
+
+  WaiterBase() = default;
+  virtual ~WaiterBase() = default;
+
+  virtual void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, TaskHolder iCallback) const = 0;
+};
+}
+#endif

--- a/WaiterBase.h
+++ b/WaiterBase.h
@@ -14,7 +14,10 @@ class WaiterBase {
   WaiterBase() = default;
   virtual ~WaiterBase() = default;
 
-  virtual void waitAsync(std::vector<DataProductRetriever> const& iRetrievers, unsigned int index, TaskHolder iCallback) const = 0;
+  // iLaneIndex is which Lane is being used to process this Event
+  // iEventIndex is the index of the event within the Source
+  // iProductIndex is which element of iRetrievers is to be waited upon
+  virtual void waitAsync(unsigned int iLaneIndex, EventIdentifier const& iEventID, long iEventIndex, std::vector<DataProductRetriever> const& iRetrievers, unsigned int iProductIndex, TaskHolder iCallback) const = 0;
 };
 }
 #endif

--- a/WaiterFactory.cc
+++ b/WaiterFactory.cc
@@ -1,0 +1,6 @@
+#include "WaiterFactory.h"
+
+using namespace cce::tf;
+
+REGISTER_COMPONENTFACTORY(WaiterFactory)
+

--- a/WaiterFactory.h
+++ b/WaiterFactory.h
@@ -6,7 +6,8 @@
 #include "ConfigurationParameters.h"
 
 namespace cce::tf {
-  using WaiterFactory = ComponentFactory<WaiterBase*(std::size_t , ConfigurationParameters const&)>;
+  // arguments are number of lanes followed by number of data products
+  using WaiterFactory = ComponentFactory<WaiterBase*(unsigned int, std::size_t , ConfigurationParameters const&)>;
   using WaiterMakerBase = WaiterFactory::CMakerBase;
 }
 

--- a/WaiterFactory.h
+++ b/WaiterFactory.h
@@ -1,0 +1,14 @@
+#if !defined(WaiterFactory_h)
+#define WaiterFactory_h
+
+#include "ComponentFactory.h"
+#include "WaiterBase.h"
+#include "ConfigurationParameters.h"
+
+namespace cce::tf {
+  using WaiterFactory = ComponentFactory<WaiterBase*(std::size_t , ConfigurationParameters const&)>;
+  using WaiterMakerBase = WaiterFactory::CMakerBase;
+}
+
+#endif
+

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -124,8 +124,12 @@ int main(int argc, char* argv[]) {
   auto out = outFactory(nLanes);
   auto source = sourceFactory(nLanes, nEvents);
   lanes.reserve(nLanes);
+  std::unique_ptr<Waiter> waiter;
+  if(scale >= 0.) {
+    waiter = std::make_unique<Waiter>(source->numberOfDataProducts(), scale);
+  }
   for(unsigned int i = 0; i< nLanes; ++i) {
-    lanes.emplace_back(i, source.get(), scale);
+    lanes.emplace_back(i, source.get(), waiter.get());
     out->setupForLane(i, lanes.back().dataProducts());
   }
 

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -12,6 +12,7 @@
 
 #include "outputerFactoryGenerator.h"
 #include "sourceFactoryGenerator.h"
+#include "Waiter.h"
 
 #include "Lane.h"
 
@@ -105,7 +106,7 @@ int main(int argc, char* argv[]) {
       std::cout <<"failed to create source\n";
       return 1;
     }
-    Lane lane(0, source.get(), 0);
+    Lane lane(0, source.get(), nullptr);
     out->setupForLane(0, lane.dataProducts());
     auto pOut = out.get();
     std::cout <<"begin warmup"<<std::endl;

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -136,7 +136,7 @@ int main(int argc, char* argv[]) {
   auto source = sourceFactory(nLanes, nEvents);
   std::unique_ptr<WaiterBase> waiter;
   if(waiterFactory) {
-    waiter = waiterFactory(source->numberOfDataProducts());
+    waiter = waiterFactory(nLanes, source->numberOfDataProducts());
   }
   lanes.reserve(nLanes);
   for(unsigned int i = 0; i< nLanes; ++i) {

--- a/waiterFactoryGenerator.cc
+++ b/waiterFactoryGenerator.cc
@@ -1,0 +1,31 @@
+#include "waiterFactoryGenerator.h"
+#include "WaiterFactory.h"
+#include "configKeyValuePairs.h"
+#include <iostream>
+
+std::function<std::unique_ptr<cce::tf::WaiterBase>(std::size_t)>
+cce::tf::waiterFactoryGenerator(std::string_view iType, std::string_view iOptions) {
+  std::function<std::unique_ptr<WaiterBase>(unsigned int)> waitFactory;
+
+  auto keyValues = cce::tf::configKeyValuePairs(iOptions);
+  waitFactory = [type=std::string(iType), params=ConfigurationParameters(keyValues)](size_t iNDataProducts) {
+    auto maker = WaiterFactory::get()->create(type, iNDataProducts, params);
+    if(not maker) {
+      return maker;
+    }
+    
+    //make sure all parameters given were used
+    auto unusedOptions = params.unusedKeys();
+    if(not unusedOptions.empty()) {
+      std::cout <<"Unused options in "<<type<<"\n";
+      for(auto const& key: unusedOptions) {
+        std::cout <<"  '"<<key<<"'"<<std::endl;
+      }
+      return decltype(maker)();
+    }
+
+    return maker;
+  };
+
+  return waitFactory;
+}

--- a/waiterFactoryGenerator.cc
+++ b/waiterFactoryGenerator.cc
@@ -3,13 +3,13 @@
 #include "configKeyValuePairs.h"
 #include <iostream>
 
-std::function<std::unique_ptr<cce::tf::WaiterBase>(std::size_t)>
+std::function<std::unique_ptr<cce::tf::WaiterBase>(unsigned int, std::size_t)>
 cce::tf::waiterFactoryGenerator(std::string_view iType, std::string_view iOptions) {
-  std::function<std::unique_ptr<WaiterBase>(unsigned int)> waitFactory;
+  std::function<std::unique_ptr<WaiterBase>(unsigned int, std::size_t)> waitFactory;
 
   auto keyValues = cce::tf::configKeyValuePairs(iOptions);
-  waitFactory = [type=std::string(iType), params=ConfigurationParameters(keyValues)](size_t iNDataProducts) {
-    auto maker = WaiterFactory::get()->create(type, iNDataProducts, params);
+  waitFactory = [type=std::string(iType), params=ConfigurationParameters(keyValues)](unsigned int iNLanes, size_t iNDataProducts) {
+    auto maker = WaiterFactory::get()->create(type, iNLanes, iNDataProducts, params);
     if(not maker) {
       return maker;
     }

--- a/waiterFactoryGenerator.h
+++ b/waiterFactoryGenerator.h
@@ -1,0 +1,13 @@
+#if !defined(waiterFactoryGenerator_h)
+#define waiterFactoryGenerator_h
+
+#include <functional>
+#include <memory>
+#include <string_view>
+#include "WaiterBase.h"
+
+namespace cce::tf {
+std::function<std::unique_ptr<WaiterBase>(size_t)>
+waiterFactoryGenerator(std::string_view iType, std::string_view iOptions);
+}
+#endif

--- a/waiterFactoryGenerator.h
+++ b/waiterFactoryGenerator.h
@@ -7,7 +7,7 @@
 #include "WaiterBase.h"
 
 namespace cce::tf {
-std::function<std::unique_ptr<WaiterBase>(size_t)>
+std::function<std::unique_ptr<WaiterBase>(unsigned int, size_t)>
 waiterFactoryGenerator(std::string_view iType, std::string_view iOptions);
 }
 #endif


### PR DESCRIPTION
- Created a WaiterBase class
- Added a waiter factory system analogous to Sources and Outputers
- Changed threaded_io_test to have a `-w` command line option to specify Waiter
- Updated documentation
- Move the original Waiter behavior into `ScaleWaiter`

The plan is to add additional Waiters so as to be able to more accurately mimic the timing for HEP data processing in order to better study throughput effects for more realistic cases.
 