### PR TITLE
Initialize loop variable

### DIFF
--- a/TestProductsSource.cc
+++ b/TestProductsSource.cc
@@ -53,7 +53,7 @@ TestProductsSource::TestProductsSource(unsigned int iNLanes, unsigned long long 
 {
   delayedPerLane_.reserve(iNLanes);
   retrieverPerLane_.reserve(iNLanes);
-  for(unsigned int lane; lane<iNLanes; ++lane) {
+  for(unsigned int lane = 0; lane<iNLanes; ++lane) {
     delayedPerLane_.emplace_back(&intsPerLane_[lane], &floatsPerLane_[lane]);
     std::vector<DataProductRetriever> r;
     r.reserve(2);


### PR DESCRIPTION
On some platforms (in my case WSL2/Ubuntu 20.04, the loop variable is not zero initialized by default (leading to the loop being skips and unchecked invariant (vector length) be false but relied on ... i.e. `terminate called after throwing an instance of 'std::length_error')

See https://github.com/Dr15Jones/root_serialization/pull/4