### PR TITLE
Add missing virtual destructor to SerialTaskQueue::TaskBase

### DIFF
--- a/SerialTaskQueue.h
+++ b/SerialTaskQueue.h
@@ -122,6 +122,8 @@ class SerialTaskQueue {
     class TaskBase {
       friend class SerialTaskQueue;
 
+      virtual ~TaskBase() = default;
+
       tbb::task_group* group() { return m_group;}
       virtual void execute() = 0 ;
     protected:

--- a/SharedPDSSource.cc
+++ b/SharedPDSSource.cc
@@ -76,17 +76,15 @@ EventIdentifier SharedPDSSource::eventIdentifier(unsigned int iLane, long iEvent
 
 void SharedPDSSource::readEventAsync(unsigned int iLane, long iEventIndex,  OptionalTaskHolder iTask) {
   queue_.push(*iTask.group(), [iLane, optTask = std::move(iTask), this]() mutable {
-      //For some reason optTask's destructor is not being called. 'move'ing to a local
-      // variable guarantees the destructor is called.
-      auto localOptTask = std::move(optTask);
+
       auto start = std::chrono::high_resolution_clock::now();
       std::vector<uint32_t> buffer;
       
       if(pds::readCompressedEventBuffer(file_, this->laneInfos_[iLane].eventID_, buffer)) {
         //last entry in buffer is just a crosscheck on its size
         buffer.pop_back();
-        auto group = localOptTask.group();
-        group->run([this, buffer=std::move(buffer), task = localOptTask.releaseToTaskHolder(), iLane]() {
+        auto group = optTask.group();
+        group->run([this, buffer=std::move(buffer), task = optTask.releaseToTaskHolder(), iLane]() {
             auto& laneInfo = this->laneInfos_[iLane];
 
             auto start = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
This accounts for why lambda's passed to SerialTaskQueue::push were not having their destructors called.

Thanks to Nick Smith for reporting a bug and pointing to the correct solution.