### PR TITLE
Update to compile with root 6.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,13 @@ REFLEX_GENERATE_DICTIONARY(G__batchevents_classes EventIdentifiers.h SELECTION b
 add_library(batchevents_classes_dict SHARED G__batchevents_classes.cxx)
 target_link_libraries(batchevents_classes_dict PUBLIC ROOT::RIO ROOT::Net)
 
+#make library holding dictionaries for RootEventOutputers
+REFLEX_GENERATE_DICTIONARY(G__rooteventoutputer_classes RootEventOutputerDict.h SELECTION RootEventOutputerDict_def.xml)
+
+add_library(rooteventoutputer_classes_dict SHARED G__rooteventoutputer_classes.cxx)
+target_link_libraries(rooteventoutputer_classes_dict PUBLIC ROOT::RIO ROOT::Net)
+
+
 add_executable(threaded_io_test
   DeserializeStrategy.cc
   EmptySource.cc
@@ -107,6 +114,7 @@ target_link_libraries(threaded_io_test
                               configKeys
                               sequence_classes_dict
                               batchevents_classes_dict
+                              rooteventoutputer_classes_dict
                               zstd::libzstd_shared)
 
 add_subdirectory(cms)

--- a/RootEventOutputerDict.h
+++ b/RootEventOutputerDict.h
@@ -1,0 +1,3 @@
+#include <vector>
+#include <utility>
+#include <string>

--- a/RootEventOutputerDict_def.xml
+++ b/RootEventOutputerDict_def.xml
@@ -1,0 +1,3 @@
+<lcgdict>
+  <class name="std::vector<std::pair<std::string,std::string>>"/>
+</lcgdict>

--- a/pds_reading.cc
+++ b/pds_reading.cc
@@ -206,7 +206,7 @@ std::vector<uint32_t> pds::uncompressEventBuffer(pds::Compression compression, s
   } else if(Compression::kZSTD == compression) {
     ZSTD_decompress(uBuffer.data(), uncompressedBufferSize*4, &(*(buffer.begin()+1)), compressedBufferSizeInBytes);
   } else if(Compression::kNone == compression) {
-    assert(buffer.size() == uBuffer.size()+2);
+    assert(buffer.size() == uBuffer.size()+1);
     std::copy(buffer.begin()+1, buffer.begin()+buffer.size(), uBuffer.begin());
   }
   return uBuffer;


### PR DESCRIPTION
ROOT 6.26 required that we have an explicit dictionary for `std::vector<std::pair<std::string, std::string>>`