### PR TITLE
WIP: spack environment file for dependencies

### DIFF
--- a/spack/spack.yaml
+++ b/spack/spack.yaml
@@ -1,0 +1,24 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+#
+# I'm keeping this one deliberately high level: you can tell your own spack
+# installation about external packages and preferred MPI implementations
+# usage:
+#    spack env activate .
+#    spack install
+
+spack:
+  modules:
+    prefix_inspections:
+      lib: [LD_LIBRARY_PATH]
+      lib64: [LD_LIBRARY_PATH]
+  specs:
+  - hdf5+mpi+hl
+  - root@master~opengl+root7~x~minuit cxxstd=17
+  - darshan-runtime
+  view: true
+  concretizer:
+    unify: true
+


### PR DESCRIPTION
We've been managing our software dependencies with spack (https://spack.io/).  This "environment" file concisely describes the dependencies of the `root_serialization` mimic.   it presumes spack and 'external' packages are all set up elsewhere.  

took me a few iterations to build ROOT with the necessary (and unnecessary) features, so I hope having them captured here will save someone else a bit of trouble. 

