### PR TITLE
pick up more ROOT api changes

### DIFF
--- a/RNTupleOutputer.cc
+++ b/RNTupleOutputer.cc
@@ -23,7 +23,7 @@ void RNTupleOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProd
     const std::string eventAuxiliaryBranchName{"EventAuxiliary"}; 
     bool hasEventAuxiliaryBranch = false;
     
-    auto model = ROOT::Experimental::RNTupleModel::CreateBare();
+    auto model = ROOT::RNTupleModel::CreateBare();
     fieldIDs_.reserve(iDPs.size());
     for(auto const& dp: iDPs) {
       // chop last . if present
@@ -33,9 +33,9 @@ void RNTupleOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProd
       auto name = dp.name().substr(0, dp.name().find("."));
       if ( config_.verbose_ > 1 ) std::cout << "-------- Creating field for " << name << " of type " << dp.classType()->GetName() << "\n";
       try { 
-        auto field = ROOT::Experimental::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
+        auto field = ROOT::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
         assert(field);
-        if ( config_.verbose_ > 1 ) ROOT::Experimental::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
+        if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
         model->AddField(std::move(field));
         fieldIDs_.emplace_back(std::move(name));
         
@@ -47,14 +47,14 @@ void RNTupleOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProd
     }
     if(not hasEventAuxiliaryBranch) {
       id_ = std::make_shared<EventIdentifier>();
-      auto field = ROOT::Experimental::RFieldBase::Create("EventID", "cce::tf::EventIdentifier").Unwrap();
-      if ( config_.verbose_ > 1 ) ROOT::Experimental::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
+      auto field = ROOT::RFieldBase::Create("EventID", "cce::tf::EventIdentifier").Unwrap();
+      if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
       assert(field);
       model->AddField(std::move(field));
       fieldIDs_.emplace_back("EventID");
     }
     // https://root.cern/doc/v626/classROOT_1_1Experimental_1_1RNTupleWriteOptions.html
-    auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+    auto writeOptions = ROOT::RNTupleWriteOptions();
     writeOptions.SetCompression(config_.compressionAlgorithm_, config_.compressionLevel_);
     writeOptions.SetMaxUnzippedPageSize(config_.maxUnzippedPageSize_);
     writeOptions.SetApproxZippedClusterSize(config_.approxZippedClusterSize_);
@@ -65,7 +65,7 @@ void RNTupleOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProd
       std::cout <<"RNTupleWriter: EstimateWriteMemoryUsage "<<model->EstimateWriteMemoryUsage(writeOptions)<<std::endl;
     }
     
-    ntuple_ = ROOT::Experimental::RNTupleWriter::Recreate(std::move(model), "Events", fileName_, writeOptions);
+    ntuple_ = ROOT::RNTupleWriter::Recreate(std::move(model), "Events", fileName_, writeOptions);
   }
   else if ( not ntuple_ ) {
     throw std::logic_error("setupForLane should be sequential");

--- a/RNTupleOutputer.h
+++ b/RNTupleOutputer.h
@@ -48,7 +48,7 @@ private:
   const RNTupleOutputerConfig config_;
 
   // initialized in lane 0 setupForLane(), modified only in collateProducts()
-  mutable std::unique_ptr<ROOT::Experimental::RNTupleWriter> ntuple_;
+  mutable std::unique_ptr<ROOT::RNTupleWriter> ntuple_;
 
   //identifiers used to specify which field to use
   std::vector<std::string> fieldIDs_;

--- a/RNTupleParallelOutputer.cc
+++ b/RNTupleParallelOutputer.cc
@@ -35,7 +35,7 @@ void RNTupleParallelOutputer::setupForLane(unsigned int iLaneIndex, std::vector<
       try { 
         auto field = ROOT::Experimental::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
         assert(field);
-        if ( config_.verbose_ > 1 ) ROOT::Experimental::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
+        if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
         model->AddField(std::move(field));
         fieldIDs_.emplace_back(std::move(name));
         
@@ -48,7 +48,7 @@ void RNTupleParallelOutputer::setupForLane(unsigned int iLaneIndex, std::vector<
     if(not hasEventAuxiliaryBranch) {
       hasEventAuxiliaryBranch_ = false;
       auto field = ROOT::Experimental::RFieldBase::Create("EventID", "cce::tf::EventIdentifier").Unwrap();
-      if ( config_.verbose_ > 1 ) ROOT::Experimental::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
+      if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
       assert(field);
       model->AddField(std::move(field));
       fieldIDs_.emplace_back("EventID");

--- a/RNTupleTFileOutputer.cc
+++ b/RNTupleTFileOutputer.cc
@@ -24,7 +24,7 @@ void RNTupleTFileOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
     const std::string eventAuxiliaryBranchName{"EventAuxiliary"}; 
     bool hasEventAuxiliaryBranch = false;
     
-    auto model = ROOT::Experimental::RNTupleModel::CreateBare();
+    auto model = ROOT::RNTupleModel::CreateBare();
     fieldIDs_.reserve(iDPs.size());
     for(auto const& dp: iDPs) {
       // chop last . if present
@@ -34,9 +34,9 @@ void RNTupleTFileOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
       auto name = dp.name().substr(0, dp.name().find("."));
       if ( config_.verbose_ > 1 ) std::cout << "-------- Creating field for " << name << " of type " << dp.classType()->GetName() << "\n";
       try { 
-        auto field = ROOT::Experimental::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
+        auto field = ROOT::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
         assert(field);
-        if ( config_.verbose_ > 1 ) ROOT::Experimental::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
+        if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
         model->AddField(std::move(field));
         fieldIDs_.emplace_back(std::move(name));
         
@@ -48,21 +48,21 @@ void RNTupleTFileOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
     }
     if(not hasEventAuxiliaryBranch) {
       id_ = std::make_shared<EventIdentifier>();
-      auto field = ROOT::Experimental::RFieldBase::Create("EventID", "cce::tf::EventIdentifier").Unwrap();
-      if ( config_.verbose_ > 1 ) ROOT::Experimental::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
+      auto field = ROOT::RFieldBase::Create("EventID", "cce::tf::EventIdentifier").Unwrap();
+      if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
       assert(field);
       model->AddField(std::move(field));
       fieldIDs_.emplace_back("EventID");
     }
     // https://root.cern/doc/v626/classROOT_1_1Experimental_1_1RNTupleWriteOptions.html
-    auto writeOptions = ROOT::Experimental::RNTupleWriteOptions();
+    auto writeOptions = ROOT::RNTupleWriteOptions();
     writeOptions.SetCompression(config_.compressionAlgorithm_, config_.compressionLevel_);
     writeOptions.SetMaxUnzippedPageSize(config_.maxUnzippedPageSize_);
     writeOptions.SetApproxZippedClusterSize(config_.approxZippedClusterSize_);
     writeOptions.SetMaxUnzippedClusterSize(config_.maxUnzippedClusterSize_);
     writeOptions.SetUseBufferedWrite(config_.useBufferedWrite_);
     
-    ntuple_ = ROOT::Experimental::RNTupleWriter::Append(std::move(model), "Events", file_, writeOptions);
+    ntuple_ = ROOT::RNTupleWriter::Append(std::move(model), "Events", file_, writeOptions);
   }
   else if ( not ntuple_ ) {
     throw std::logic_error("setupForLane should be sequential");

--- a/RNTupleTFileOutputer.h
+++ b/RNTupleTFileOutputer.h
@@ -50,7 +50,7 @@ private:
 
   TFile file_;
   // initialized in lane 0 setupForLane(), modified only in collateProducts()
-  mutable std::unique_ptr<ROOT::Experimental::RNTupleWriter> ntuple_;
+  mutable std::unique_ptr<ROOT::RNTupleWriter> ntuple_;
 
   //identifiers used to specify which field to use
   std::vector<std::string> fieldIDs_;

--- a/SerialRNTupleSource.cc
+++ b/SerialRNTupleSource.cc
@@ -29,7 +29,7 @@ SerialRNTupleSource::SerialRNTupleSource(unsigned iNLanes, unsigned long long iN
   bool hasEventID = false;
   bool hasEventAux = false;
   auto const& model = events_->GetModel();
-  auto const& subfields = model.GetConstFieldZero().GetSubFields();
+  auto const& subfields = model.GetConstFieldZero().GetConstSubfields();
   std::vector<std::string> fieldIDs;
   fieldIDs.reserve(subfields.size());
   std::vector<std::string> fieldType;

--- a/SerialRNTupleSource.h
+++ b/SerialRNTupleSource.h
@@ -41,7 +41,7 @@ namespace cce::tf {
     std::chrono::microseconds accumulatedTime_;
 
     //per lane items
-    std::vector<std::unique_ptr<ROOT::Experimental::REntry>> entries_;
+    std::vector<std::unique_ptr<ROOT::REntry>> entries_;
     std::vector<SerialRNTuplePromptRetriever> promptReaders_;
     std::vector<SerialRNTupleDelayedRetriever> delayedReaders_;
     std::vector<EventIdentifier> identifiers_;

--- a/SerialRNTupleTFileSource.cc
+++ b/SerialRNTupleTFileSource.cc
@@ -32,7 +32,7 @@ SerialRNTupleTFileSource::SerialRNTupleTFileSource(unsigned iNLanes, unsigned lo
   bool hasEventID = false;
   bool hasEventAux = false;
   auto const& model = events_->GetModel();
-  auto const& subfields = model.GetConstFieldZero().GetSubFields();
+  auto const& subfields = model.GetConstFieldZero().GetConstSubfields();
   std::vector<std::string> fieldIDs;
   fieldIDs.reserve(subfields.size());
   std::vector<std::string> fieldType;

--- a/SerialRNTupleTFileSource.h
+++ b/SerialRNTupleTFileSource.h
@@ -44,7 +44,7 @@ namespace cce::tf {
     std::chrono::microseconds accumulatedTime_;
 
     //per lane items
-    std::vector<std::unique_ptr<ROOT::Experimental::REntry>> entries_;
+    std::vector<std::unique_ptr<ROOT::REntry>> entries_;
     std::vector<SerialRNTuplePromptRetriever> promptReaders_;
     std::vector<SerialRNTupleDelayedRetriever> delayedReaders_;
     std::vector<EventIdentifier> identifiers_;


### PR DESCRIPTION
more RNTuple features are moving out of experimental.  This changeset makes root_serialization build against ROOT from 1 April checkout. 