### PR TITLE
SerialRootSource now has buffers per product per lane

### DIFF
--- a/SerialRootSource.h
+++ b/SerialRootSource.h
@@ -23,14 +23,16 @@ namespace cce::tf {
     SerialRootDelayedRetriever(SerialTaskQueue* iQueue,
                                std::vector<TBranch*>* iBranches):
     queue_(iQueue), branches_(iBranches),
-      accumulatedTime_{std::chrono::microseconds::zero()}{}
+    accumulatedTime_{std::chrono::microseconds::zero()}{setupBuffer();}
     void getAsync(DataProductRetriever&, int index, TaskHolder) final;
     void setEntry(long iEntry) { entry_ = iEntry; }
     std::chrono::microseconds accumulatedTime() const { return accumulatedTime_;}
 
   private:
+    void setupBuffer();
     SerialTaskQueue* queue_;
     std::vector<TBranch*>* branches_;
+    std::vector<void*> buffers_;
     std::chrono::microseconds accumulatedTime_;
     long entry_ = -1;
   };


### PR DESCRIPTION
Previously all lanes shared the same product buffers which lead to concurrency problems (writing to the buffer while a different event read from it).