### PR TITLE
Additional options for writing RNTuples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ add_executable(threaded_io_test
   RNTupleAsyncOutputer.cc
   RNTupleParallelOutputer.cc
   RNTupleOutputerConfig.cc
+  RNTupleOutputerFieldMaker.cc
   SerialRNTupleSource.cc
   SerialRNTupleTFileSource.cc
   SerialRNTupleRetrievers.cc
@@ -183,6 +184,8 @@ add_test(NAME EventSleepWaiterTest COMMAND bash -c "echo 300000 > times.wait; ${
 
 add_test(NAME RNTupleOutputerEmptyTest COMMAND threaded_io_test -s EmptySource -t 1 -n 10 -o RNTupleOutputer=test_empty.rntpl)
 add_test(NAME RNTupleOutputerTestProducts COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s TestProductsSource -t 1 -n 10 -o RNTupleOutputer=test_prod.rntpl; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s SerialRNTupleSource=test_prod.rntpl -t 1 -n 10 -o TestProductsOutputer")
+add_test(NAME RNTupleOutputerTestProductsNoSplit COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s TestProductsSource -t 1 -n 10 -o RNTupleOutputer=test_prod_nosplit.rntpl:noSplitFields=all; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s SerialRNTupleSource=test_prod_nosplit.rntpl -t 1 -n 10 -o TestProductsOutputer")
+add_test(NAME RNTupleOutputerTestProductsExplicitNoSplit COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s TestProductsSource -t 1 -n 10 -o RNTupleOutputer=test_prod_nosplit.rntpl:noSplitFields=ints._0,floats._0; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s SerialRNTupleSource=test_prod_nosplit.rntpl -t 1 -n 10 -o TestProductsOutputer")
 add_test(NAME RNTupleOutputerDelayedReadTestProducts COMMAND bash -c "${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s TestProductsSource -t 1 -n 10 -o RNTupleOutputer=test_prod.rntpl; ${CMAKE_CURRENT_BINARY_DIR}/threaded_io_test -s SerialRNTupleSource=test_prod.rntpl:delayReading=y -t 1 -n 10 -o TestProductsOutputer")
 
 add_test(NAME RNTupleTFileOutputerEmptyTest COMMAND threaded_io_test -s EmptySource -t 1 -n 10 -o RNTupleTFileOutputer=test_empty.rntpl)

--- a/README.md
+++ b/README.md
@@ -241,11 +241,15 @@ or
 Writes the _event_ data products into a ROOT file using an RNTuple. Specify both the name of the Outputer and the file to write as well as many  optional parameters:
 - compressionLevel: compression level 0-9, default 9
 - compressionAlgorithm: name of compression algorithm. Allowed valued "", "zlib", "lzma", "lz4", "zstd"
-- approxUnzippedPageSize:  should be just large enough so compression algorithm doesn't benefit from larger page sizes: Default size 64*1024
-- approxZippedClusterSize: Target compressed cluster size: Default size 50,000,000
-- maxUnzippedClusterSize: Memory limit for commiting a cluster. Default 512*1024*1024
-- hasSmallClusters: If 'true', use 32 bit index columns instead of 64 bit columns. Limits cluster size to 512MB. Default false
+- approxZippedClusterSize: Target compressed cluster size: Default size is ROOT's default.
+- maxUnzippedClusterSize: Memory limit for commiting a cluster. Default is ROOT's default.
+- initialUnzippedPageSize: Initially, columns start with a page of this size (bytes). 
+- pageBufferBudget:The maximum size that the sum of all page buffers used for writing into a persistent sink are allowed to use. If set to zero, RNTuple will auto-adjust the budget based on the value of 'approxZippedClusterSize'. If set manually, the size needs to be large enough to hold all initial page buffers.
+- useDirectIO: Set use of direct IO. this introduces alignment requirements that may vary between filesystems and platforms.
 - useBufferedWrite: default true
+- enablePageChecksums: default true
+- printEstimateWriteMemoryUsage: 
+- noSplitFields: a comma separated list of sub field names which should not be split. If 'all' is given as the only field name, all possible fields will not be split.
 ```
 > threaded_io_test -s ReplicatedRootSource=test.root -t 1 -n 10 -o RNTupleOutputer=test.rntpl
 ```

--- a/RNTupleAsyncOutputer.cc
+++ b/RNTupleAsyncOutputer.cc
@@ -3,6 +3,7 @@
 #include "OutputerFactory.h"
 #include "FunctorTask.h"
 #include "RNTupleOutputerConfig.h"
+#include "RNTupleOutputerFieldMaker.h"
 
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RField.hxx>
@@ -25,6 +26,7 @@ void RNTupleAsyncOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
     
     auto model = ROOT::RNTupleModel::CreateBare();
     fieldIDs_.reserve(iDPs.size());
+    RNTupleOutputerFieldMaker fieldMaker(config_);
     for(auto const& dp: iDPs) {
       // chop last . if present
       if(dp.name() == eventAuxiliaryBranchName) {
@@ -33,7 +35,7 @@ void RNTupleAsyncOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
       auto name = dp.name().substr(0, dp.name().find("."));
       if ( config_.verbose_ > 1 ) std::cout << "-------- Creating field for " << name << " of type " << dp.classType()->GetName() << "\n";
       try { 
-        auto field = ROOT::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
+        auto field = fieldMaker.make(name, dp.classType()->GetName());
         assert(field);
         if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
         model->AddField(std::move(field));

--- a/RNTupleAsyncOutputer.cc
+++ b/RNTupleAsyncOutputer.cc
@@ -54,12 +54,7 @@ void RNTupleAsyncOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
       fieldIDs_.emplace_back("EventID");
     }
     // https://root.cern/doc/v626/classROOT_1_1Experimental_1_1RNTupleWriteOptions.html
-    auto writeOptions = ROOT::RNTupleWriteOptions();
-    writeOptions.SetCompression(config_.compressionAlgorithm_, config_.compressionLevel_);
-    writeOptions.SetMaxUnzippedPageSize(config_.maxUnzippedPageSize_);
-    writeOptions.SetApproxZippedClusterSize(config_.approxZippedClusterSize_);
-    writeOptions.SetMaxUnzippedClusterSize(config_.maxUnzippedClusterSize_);
-    writeOptions.SetUseBufferedWrite(config_.useBufferedWrite_);
+    auto writeOptions = writeOptionsFrom(config_);
     
     ntuple_ = ROOT::Experimental::RNTupleParallelWriter::Recreate(std::move(model), "Events", fileName_, writeOptions);
   }

--- a/RNTupleOutputer.cc
+++ b/RNTupleOutputer.cc
@@ -54,13 +54,7 @@ void RNTupleOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProd
       fieldIDs_.emplace_back("EventID");
     }
     // https://root.cern/doc/v626/classROOT_1_1Experimental_1_1RNTupleWriteOptions.html
-    auto writeOptions = ROOT::RNTupleWriteOptions();
-    writeOptions.SetCompression(config_.compressionAlgorithm_, config_.compressionLevel_);
-    writeOptions.SetMaxUnzippedPageSize(config_.maxUnzippedPageSize_);
-    writeOptions.SetApproxZippedClusterSize(config_.approxZippedClusterSize_);
-    writeOptions.SetMaxUnzippedClusterSize(config_.maxUnzippedClusterSize_);
-    writeOptions.SetUseBufferedWrite(config_.useBufferedWrite_);
-    writeOptions.SetEnablePageChecksums(config_.enablePageChecksums_);
+    auto writeOptions = writeOptionsFrom(config_);
     if(config_.printEstimateWriteMemoryUsage_) {
       std::cout <<"RNTupleWriter: EstimateWriteMemoryUsage "<<model->EstimateWriteMemoryUsage(writeOptions)<<std::endl;
     }

--- a/RNTupleOutputer.cc
+++ b/RNTupleOutputer.cc
@@ -3,6 +3,7 @@
 #include "OutputerFactory.h"
 #include "FunctorTask.h"
 #include "RNTupleOutputerConfig.h"
+#include "RNTupleOutputerFieldMaker.h"
 
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RField.hxx>
@@ -25,6 +26,7 @@ void RNTupleOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProd
     
     auto model = ROOT::RNTupleModel::CreateBare();
     fieldIDs_.reserve(iDPs.size());
+    RNTupleOutputerFieldMaker fieldMaker(config_);
     for(auto const& dp: iDPs) {
       // chop last . if present
       if(dp.name() == eventAuxiliaryBranchName) {
@@ -33,12 +35,11 @@ void RNTupleOutputer::setupForLane(unsigned int iLaneIndex, std::vector<DataProd
       auto name = dp.name().substr(0, dp.name().find("."));
       if ( config_.verbose_ > 1 ) std::cout << "-------- Creating field for " << name << " of type " << dp.classType()->GetName() << "\n";
       try { 
-        auto field = ROOT::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
+        auto field = fieldMaker.make(name, dp.classType()->GetName());
         assert(field);
         if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
         model->AddField(std::move(field));
         fieldIDs_.emplace_back(std::move(name));
-        
       }
       catch (ROOT::RException& e) {
          std::cout << "Failed: " << e.what() << "\n";

--- a/RNTupleOutputerConfig.cc
+++ b/RNTupleOutputerConfig.cc
@@ -4,13 +4,30 @@
 #include <iostream>
 
 namespace cce::tf {
+  namespace {
+    std::set<std::string> parseSplitFields(std::string const& iFields) {
+      //Eventually should given an option to read a file containing the fields
+      std::set<std::string> fields;
+      if (iFields.empty()) {
+        return fields;
+      }
+      std::size_t lastComma = 0;
+      std::size_t tokenStart = 0;
+      while(std::string::npos != (lastComma = iFields.find(',',tokenStart))) {
+        fields.insert(iFields.substr(tokenStart, lastComma-tokenStart));
+        tokenStart = lastComma + 1;
+      }
+      fields.insert(iFields.substr(tokenStart, lastComma-tokenStart));
+      return fields;
+    }
+  }
+  
   std::optional<std::pair<std::string, RNTupleOutputerConfig>> parseRNTupleConfig(ConfigurationParameters const& params) {
     auto fileName = params.get<std::string>("fileName");
     if(not fileName) {
       std::cout <<"no file name given for Outputer\n";
       return std::nullopt;
     }
-
     RNTupleOutputerConfig config;
     config.compressionLevel_ = params.get<int>("compressionLevel", config.compressionLevel_);
     auto compressionAlgo = params.get<std::string>("compressionAlgorithm", "");
@@ -29,6 +46,7 @@ namespace cce::tf {
     }
     config.verbose_ = params.get<int>("verbose", config.verbose_);
     config.maxUnzippedPageSize_ = params.get<std::size_t>("maxUnzippedPageSize", config.maxUnzippedPageSize_);
+    config.initialUnzippedPageSize_ = params.get<std::size_t>("initialUnzippedPageSize", config.initialUnzippedPageSize_);
     config.approxZippedClusterSize_ = params.get<std::size_t>("approxZippedClusterSize", config.approxZippedClusterSize_);
     config.maxUnzippedClusterSize_ = params.get<std::size_t>("maxUnzippedClusterSize", config.maxUnzippedClusterSize_);
     config.pageBufferBudget_ = params.get<std::size_t>("pageBufferBudget", config.pageBufferBudget_);
@@ -36,6 +54,7 @@ namespace cce::tf {
     config.useDirectIO_ = params.get<bool>("useDirectIO", config.useDirectIO_);
     config.enablePageChecksums_ = params.get<bool>("enablePageChecksums", config.enablePageChecksums_);
     config.printEstimateWriteMemoryUsage_ = params.get<bool>("printEstimateWriteMemoryUsage", config.printEstimateWriteMemoryUsage_);
+    config.noSplitFields_ = parseSplitFields(params.get<std::string>("noSplitFields",""));
     return std::make_pair(*fileName,config);
   }
 
@@ -43,6 +62,7 @@ namespace cce::tf {
     ROOT::RNTupleWriteOptions writeOptions;
     writeOptions.SetCompression(config.compressionAlgorithm_, config.compressionLevel_);
     writeOptions.SetMaxUnzippedPageSize(config.maxUnzippedPageSize_);
+    writeOptions.SetInitialUnzippedPageSize(config.initialUnzippedPageSize_);
     writeOptions.SetApproxZippedClusterSize(config.approxZippedClusterSize_);
     writeOptions.SetMaxUnzippedClusterSize(config.maxUnzippedClusterSize_);
     writeOptions.SetPageBufferBudget(config.pageBufferBudget_);

--- a/RNTupleOutputerConfig.cc
+++ b/RNTupleOutputerConfig.cc
@@ -31,9 +31,26 @@ namespace cce::tf {
     config.maxUnzippedPageSize_ = params.get<std::size_t>("maxUnzippedPageSize", config.maxUnzippedPageSize_);
     config.approxZippedClusterSize_ = params.get<std::size_t>("approxZippedClusterSize", config.approxZippedClusterSize_);
     config.maxUnzippedClusterSize_ = params.get<std::size_t>("maxUnzippedClusterSize", config.maxUnzippedClusterSize_);
+    config.pageBufferBudget_ = params.get<std::size_t>("pageBufferBudget", config.pageBufferBudget_);
     config.useBufferedWrite_ = params.get<bool>("useBufferedWrite", config.useBufferedWrite_);
+    config.useDirectIO_ = params.get<bool>("useDirectIO", config.useDirectIO_);
     config.enablePageChecksums_ = params.get<bool>("enablePageChecksums", config.enablePageChecksums_);
     config.printEstimateWriteMemoryUsage_ = params.get<bool>("printEstimateWriteMemoryUsage", config.printEstimateWriteMemoryUsage_);
     return std::make_pair(*fileName,config);
   }
+
+  ROOT::RNTupleWriteOptions writeOptionsFrom(RNTupleOutputerConfig const& config) {
+    ROOT::RNTupleWriteOptions writeOptions;
+    writeOptions.SetCompression(config.compressionAlgorithm_, config.compressionLevel_);
+    writeOptions.SetMaxUnzippedPageSize(config.maxUnzippedPageSize_);
+    writeOptions.SetApproxZippedClusterSize(config.approxZippedClusterSize_);
+    writeOptions.SetMaxUnzippedClusterSize(config.maxUnzippedClusterSize_);
+    writeOptions.SetPageBufferBudget(config.pageBufferBudget_);
+    writeOptions.SetUseBufferedWrite(config.useBufferedWrite_);
+    writeOptions.SetUseDirectIO(config.useDirectIO_);
+    writeOptions.SetEnablePageChecksums(config.enablePageChecksums_);
+
+    return writeOptions;
+  }
+
 }

--- a/RNTupleOutputerConfig.h
+++ b/RNTupleOutputerConfig.h
@@ -3,6 +3,8 @@
 
 #include <optional>
 #include <utility>
+#include <set>
+#include <string>
 #include <Compression.h>
 #include <ROOT/RNTupleWriter.hxx>
 
@@ -11,14 +13,17 @@ namespace cce::tf {
     RNTupleOutputerConfig() {
       ROOT::RNTupleWriteOptions options;
       maxUnzippedPageSize_ = options.GetMaxUnzippedPageSize();
-      approxZippedClusterSize_ = options.GetApproxZippedClusterSize();
+      initialUnzippedPageSize_ = options.GetInitialUnzippedPageSize();
+  approxZippedClusterSize_ = options.GetApproxZippedClusterSize();
       maxUnzippedClusterSize_ = options.GetMaxUnzippedClusterSize();
       pageBufferBudget_ = options.GetPageBufferBudget();
     }
+    std::set<std::string> noSplitFields_;
     int verbose_=0;
     int compressionLevel_=9;
     ROOT::RCompressionSetting::EAlgorithm::EValues compressionAlgorithm_= ROOT::RCompressionSetting::EAlgorithm::kUseGlobal;
     std::size_t maxUnzippedPageSize_;
+    std::size_t initialUnzippedPageSize_;
     std::size_t approxZippedClusterSize_;
     std::size_t maxUnzippedClusterSize_;
     std::size_t pageBufferBudget_;

--- a/RNTupleOutputerConfig.h
+++ b/RNTupleOutputerConfig.h
@@ -4,17 +4,26 @@
 #include <optional>
 #include <utility>
 #include <Compression.h>
-
+#include <ROOT/RNTupleWriter.hxx>
 
 namespace cce::tf {
   struct RNTupleOutputerConfig {
+    RNTupleOutputerConfig() {
+      ROOT::RNTupleWriteOptions options;
+      maxUnzippedPageSize_ = options.GetMaxUnzippedPageSize();
+      approxZippedClusterSize_ = options.GetApproxZippedClusterSize();
+      maxUnzippedClusterSize_ = options.GetMaxUnzippedClusterSize();
+      pageBufferBudget_ = options.GetPageBufferBudget();
+    }
     int verbose_=0;
     int compressionLevel_=9;
     ROOT::RCompressionSetting::EAlgorithm::EValues compressionAlgorithm_= ROOT::RCompressionSetting::EAlgorithm::kUseGlobal;
-    std::size_t maxUnzippedPageSize_ = 64 * 1024;
-    std::size_t approxZippedClusterSize_ = 50 * 1000 * 1000;
-    std::size_t maxUnzippedClusterSize_ = 512 * 1024 * 1024;
+    std::size_t maxUnzippedPageSize_;
+    std::size_t approxZippedClusterSize_;
+    std::size_t maxUnzippedClusterSize_;
+    std::size_t pageBufferBudget_;
     bool useBufferedWrite_=true;
+    bool useDirectIO_=true;
     bool enablePageChecksums_=true;
     bool printEstimateWriteMemoryUsage_=false;
   };
@@ -23,6 +32,7 @@ namespace cce::tf {
   class ConfigurationParameters;
 
   std::optional<std::pair<std::string, RNTupleOutputerConfig>> parseRNTupleConfig(ConfigurationParameters const& params);
+  ROOT::RNTupleWriteOptions writeOptionsFrom(RNTupleOutputerConfig const&);
 }
 
 

--- a/RNTupleOutputerFieldMaker.cc
+++ b/RNTupleOutputerFieldMaker.cc
@@ -1,0 +1,65 @@
+#include "RNTupleOutputerFieldMaker.h"
+#include <cassert>
+#include <format>
+
+namespace cce::tf {
+  
+  namespace {
+    void noSplitField(ROOT::RFieldBase& iField) {
+      auto const& typeName = iField.GetTypeName();
+      if (typeName == "std::uint16_t") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kUInt16}});
+      } else if (typeName == "std::uint32_t") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kUInt32}});
+      } else if (typeName == "std::uint64_t") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kUInt64}});
+      } else if (typeName == "std::int16_t") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt16}});
+      } else if (typeName == "std::int32_t") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt32}});
+      } else if (typeName == "std::int64_t") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kInt64}});
+      } else if (typeName == "float") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal32}});
+      } else if (typeName == "double") {
+        iField.SetColumnRepresentatives({{ROOT::ENTupleColumnType::kReal64}});
+      }
+    }
+    void applyNoSplitToSubFields(ROOT::RFieldBase& iField) {
+      for (auto& subfield : iField) {
+        noSplitField(subfield);
+        applyNoSplitToSubFields(subfield);
+      }
+    }
+  }  // namespace
+  
+  RNTupleOutputerFieldMaker::RNTupleOutputerFieldMaker(RNTupleOutputerConfig const& iConfig): noSplitFields_(iConfig.noSplitFields_) {}
+
+  std::unique_ptr<ROOT::RFieldBase> RNTupleOutputerFieldMaker::make(std::string const& iName, std::string const& iType) const {
+    auto field = ROOT::RFieldBase::Create(iName, iType).Unwrap();
+    assert(field);
+    if (noSplitFields_.size() == 1 and *noSplitFields_.begin() == "all") {
+      noSplitField(*field);
+      applyNoSplitToSubFields(*field);
+    } else if(not noSplitFields_.empty()) {
+      for (auto const& name : noSplitFields_) {
+        if (name.starts_with(iName)) {
+          bool found = false;
+          for (auto& subfield : *field) {
+            if (subfield.GetQualifiedFieldName() == name) {
+              found = true;
+              noSplitField(subfield);
+              break;
+            }
+          }
+          if (not found) {
+            throw std::runtime_error(
+              std::format("The data product was found but the requested subfield '{}' is not part of the class", iName));
+          }
+        }
+      }
+    
+    }
+    return field;
+  }
+}

--- a/RNTupleOutputerFieldMaker.h
+++ b/RNTupleOutputerFieldMaker.h
@@ -1,0 +1,22 @@
+#if !defined(RNTupleOutputerFieldMaker_h)
+#define RNTupleOutputerFieldMaker_h
+
+#include <ROOT/RNTupleWriter.hxx>
+#include "RNTupleOutputerConfig.h"
+
+#include <string>
+#include <set>
+
+namespace cce::tf {
+  class RNTupleOutputerFieldMaker {
+  public:
+    RNTupleOutputerFieldMaker(RNTupleOutputerConfig const&);
+
+    std::unique_ptr<ROOT::RFieldBase> make(std::string const& iName, std::string const& iType) const;
+  private:
+    std::set<std::string> noSplitFields_;
+  };
+}
+
+
+#endif

--- a/RNTupleParallelOutputer.cc
+++ b/RNTupleParallelOutputer.cc
@@ -3,6 +3,7 @@
 #include "OutputerFactory.h"
 #include "FunctorTask.h"
 #include "RNTupleOutputerConfig.h"
+#include "RNTupleOutputerFieldMaker.h"
 
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RField.hxx>
@@ -25,6 +26,7 @@ void RNTupleParallelOutputer::setupForLane(unsigned int iLaneIndex, std::vector<
     
     auto model = ROOT::RNTupleModel::CreateBare();
     fieldIDs_.reserve(iDPs.size());
+    RNTupleOutputerFieldMaker fieldMaker(config_);
     for(auto const& dp: iDPs) {
       // chop last . if present
       if(dp.name() == eventAuxiliaryBranchName) {
@@ -33,7 +35,7 @@ void RNTupleParallelOutputer::setupForLane(unsigned int iLaneIndex, std::vector<
       auto name = dp.name().substr(0, dp.name().find("."));
       if ( config_.verbose_ > 1 ) std::cout << "-------- Creating field for " << name << " of type " << dp.classType()->GetName() << "\n";
       try { 
-        auto field = ROOT::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
+        auto field = fieldMaker.make(name, dp.classType()->GetName());
         assert(field);
         if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
         model->AddField(std::move(field));

--- a/RNTupleParallelOutputer.cc
+++ b/RNTupleParallelOutputer.cc
@@ -54,12 +54,7 @@ void RNTupleParallelOutputer::setupForLane(unsigned int iLaneIndex, std::vector<
       fieldIDs_.emplace_back("EventID");
     }
     // https://root.cern/doc/v626/classROOT_1_1Experimental_1_1RNTupleWriteOptions.html
-    auto writeOptions = ROOT::RNTupleWriteOptions();
-    writeOptions.SetCompression(config_.compressionAlgorithm_, config_.compressionLevel_);
-    writeOptions.SetMaxUnzippedPageSize(config_.maxUnzippedPageSize_);
-    writeOptions.SetApproxZippedClusterSize(config_.approxZippedClusterSize_);
-    writeOptions.SetMaxUnzippedClusterSize(config_.maxUnzippedClusterSize_);
-    writeOptions.SetUseBufferedWrite(config_.useBufferedWrite_);
+    auto writeOptions = writeOptionsFrom(config_);
     
     ntuple_ = ROOT::Experimental::RNTupleParallelWriter::Recreate(std::move(model), "Events", fileName_, writeOptions);
   }

--- a/RNTupleTFileOutputer.cc
+++ b/RNTupleTFileOutputer.cc
@@ -55,12 +55,7 @@ void RNTupleTFileOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
       fieldIDs_.emplace_back("EventID");
     }
     // https://root.cern/doc/v626/classROOT_1_1Experimental_1_1RNTupleWriteOptions.html
-    auto writeOptions = ROOT::RNTupleWriteOptions();
-    writeOptions.SetCompression(config_.compressionAlgorithm_, config_.compressionLevel_);
-    writeOptions.SetMaxUnzippedPageSize(config_.maxUnzippedPageSize_);
-    writeOptions.SetApproxZippedClusterSize(config_.approxZippedClusterSize_);
-    writeOptions.SetMaxUnzippedClusterSize(config_.maxUnzippedClusterSize_);
-    writeOptions.SetUseBufferedWrite(config_.useBufferedWrite_);
+    auto writeOptions = writeOptionsFrom(config_);
     
     ntuple_ = ROOT::RNTupleWriter::Append(std::move(model), "Events", file_, writeOptions);
   }

--- a/RNTupleTFileOutputer.cc
+++ b/RNTupleTFileOutputer.cc
@@ -3,6 +3,7 @@
 #include "OutputerFactory.h"
 #include "FunctorTask.h"
 #include "RNTupleOutputerConfig.h"
+#include "RNTupleOutputerFieldMaker.h"
 
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RField.hxx>
@@ -26,6 +27,7 @@ void RNTupleTFileOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
     
     auto model = ROOT::RNTupleModel::CreateBare();
     fieldIDs_.reserve(iDPs.size());
+    RNTupleOutputerFieldMaker fieldMaker(config_);
     for(auto const& dp: iDPs) {
       // chop last . if present
       if(dp.name() == eventAuxiliaryBranchName) {
@@ -34,7 +36,7 @@ void RNTupleTFileOutputer::setupForLane(unsigned int iLaneIndex, std::vector<Dat
       auto name = dp.name().substr(0, dp.name().find("."));
       if ( config_.verbose_ > 1 ) std::cout << "-------- Creating field for " << name << " of type " << dp.classType()->GetName() << "\n";
       try { 
-        auto field = ROOT::RFieldBase::Create(name, dp.classType()->GetName()).Unwrap();
+        auto field = fieldMaker.make(name, dp.classType()->GetName());
         assert(field);
         if ( config_.verbose_ > 1 ) ROOT::Internal::RPrintSchemaVisitor(std::cout, '*', 1000, 10).VisitField(*field);
         model->AddField(std::move(field));


### PR DESCRIPTION
- Updated to new values settable in ROOT::RNTupleWriteOptions
- Can specify which Fields should not be split